### PR TITLE
Replace all of the backslashes in partial names to correctly name deeply nested partials.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -187,7 +187,7 @@ internals.Manager.prototype._loadPartials = function (engine) {
         files.forEach(function (file) {
 
             var offset = path.slice(-1) === Path.sep ? 0 : 1;
-            var name = file.slice(path.length + offset, -engine.suffix.length).replace('\\', '/');
+            var name = file.slice(path.length + offset, -engine.suffix.length).replace(/\\/g, '/');
             var src = Fs.readFileSync(file).toString(engine.config.encoding);
             engine.module.registerPartial(name, src);
         });


### PR DESCRIPTION
Allowing partial names like one/nested/partial to be used. Currently only the first backslash is replaced so it would be named one/nested\partial on Windows.
