### PR TITLE
Fix crash when no global context is supplied, no handler context is supplied, and a layout template is being used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -283,6 +283,8 @@ internals.Manager.prototype.render = function (filename, context, options, callb
         context = base;
     }
 
+    context = context || {};
+
     var engine = null;
 
     var fileExtension = Path.extname(filename).slice(1);

--- a/test/index.js
+++ b/test/index.js
@@ -663,6 +663,22 @@ describe('Manager', function () {
             });
         });
 
+        it('renders without handler/global-context (with layout)', function (done) {
+
+            var testView = new Vision.Manager({
+                engines: { html: require('handlebars') },
+                path: __dirname + '/templates',
+                layout: true
+            });
+
+            testView.render('valid/test', null, null, function (err, rendered, config) {
+
+                expect(rendered).to.exist();
+                expect(rendered).to.contain('<div>\n    <h1></h1>\n</div>\n');
+                done();
+            });
+        });
+
         it('renders with a global context object', function (done) {
 
             var testView = new Vision.Manager({


### PR DESCRIPTION
Fix crash when no global context is supplied, no handler context is supplied, and a layout template is being used. Couldn't find a decent way to add a test, but the coverage is still 100% :) 

Fixes #16 
