### PR TITLE
Helpful path location checked

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -417,7 +417,7 @@ internals.Manager.prototype._path = function (template, settings, isLayout, next
     },
     function () {
 
-        return next(Boom.badImplementation('View file not found: ' + template));
+        return next(Boom.badImplementation('View file not found: `' + template + '`. Locations searched: [' + paths.join(',') + ']'));
     });
 };
 


### PR DESCRIPTION
I've run across this a few times during development where there's been an extra `.` or some such in the file path, which makes it fail, but makes it less than obvious to find in the code. Having the locations which were searched for the file is very helpful when debugging this.