### PR TITLE
Ensure _loaderHelpers registers actual filenames

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -251,7 +251,7 @@ internals.Manager.prototype._loadHelpers = function (engine) {
                     var helper = require(file);
                     if (typeof helper === 'function') {
                         var offset = path.slice(-1) === Path.sep ? 0 : 1;
-                        var name = file.slice(path.length + offset, -3);
+                        var name = file.slice(path.length + offset, -Path.extname(file).length);
                         engine.module.registerHelper(name, helper);
                     }
                 }

--- a/test/templates/valid/helpers/long.javascript
+++ b/test/templates/valid/helpers/long.javascript
@@ -1,0 +1,4 @@
+exports = module.exports = function (context) {
+
+    return context;
+};

--- a/test/templates/valid/testHelpers.html
+++ b/test/templates/valid/testHelpers.html
@@ -1,1 +1,1 @@
-<p>This is all {{uppercase this.something}} and this is how we like it!</p>
+<p>This is all {{uppercase this.something}} and this is {{long "how"}} we like it!</p>


### PR DESCRIPTION
Slicing a path by the last 3 characters works for two character extensions, e.g. `'.js'` or `'.cs'` but not for longer extensions (`'.es6'` for example).

Using `Path.extname` will extract the proper extension name from a path, enabling support for files with long extensions.