### PR TITLE
Fix linter errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "code": "1.x.x",
     "hapi": "8.x.x",
-    "lab": "5.x.x",
+    "lab": "5.9.x",
     "handlebars": "3.x.x",
     "jade": "1.x.x"
   },


### PR DESCRIPTION
Minor updates to Lab cause previously passing code to fail the
build. This change constrains the Lab dependency to only
automatically install patch updates. This should prevent automatic
updates from breaking the build. Future PRs should update the Lab
dependency and fix issues in the code simultaneously to get new
style rules.