### PR TITLE
Fix lint errors.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ internals.schema = Joi.alternatives([
 ]);
 
 
-exports.register = function (server, options, next) {
+exports.register = function (server, pluginOptions, next) {
 
     server.decorate('server', 'views', function (options) {
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -344,14 +344,14 @@ internals.Manager.prototype.render = function (filename, context, options, callb
                         return callback(err);
                     }
 
-                    compiled(context, settings.runtimeOptions, function (err, rendered) {
+                    compiled(context, settings.runtimeOptions, function (err, renderedContent) {
 
                         if (err) {
                             return callback(Boom.badImplementation(err.message, err));
                         }
 
-                        context[settings.layoutKeyword] = rendered;
-                        layout(context, settings.runtimeOptions, function (err, rendered) {
+                        context[settings.layoutKeyword] = renderedContent;
+                        layout(context, settings.runtimeOptions, function (err, renderedWithLayout) {
 
                             delete context[settings.layoutKeyword];
 
@@ -359,7 +359,7 @@ internals.Manager.prototype.render = function (filename, context, options, callb
                                 return callback(Boom.badImplementation(err.message, err));
                             }
 
-                            return callback(null, rendered, settings);
+                            return callback(null, renderedWithLayout, settings);
                         });
                     });
                 });

--- a/test/index.js
+++ b/test/index.js
@@ -482,13 +482,13 @@ describe('views()', function () {
         server.register({ register: test, options: { message: 'viewing it' } }, function (err) {
 
             expect(err).to.not.exist();
-            server.inject('/view', function (res) {
+            server.inject('/view', function (viewResponse) {
 
-                expect(res.result).to.equal('<h1>viewing it</h1>');
+                expect(viewResponse.result).to.equal('<h1>viewing it</h1>');
 
-                server.inject('/ext', function (res) {
+                server.inject('/ext', function (extResponse) {
 
-                    expect(res.result).to.equal('<h1>grabbed</h1>');
+                    expect(extResponse.result).to.equal('<h1>grabbed</h1>');
                     done();
                 });
             });

--- a/test/manager.js
+++ b/test/manager.js
@@ -245,9 +245,9 @@ describe('Manager', function () {
             engines: {
                 html: {
                     module: {
-                        compile: function (template, options) {
+                        compile: function (template, compileOptions) {
 
-                            return function (context, options) {
+                            return function (context, renderOptions) {
 
                                 return undefined;
                             };
@@ -1402,15 +1402,15 @@ describe('Manager', function () {
                 }
             });
 
-            views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, rendered, config) {
+            views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, original, originalConfig) {
 
-                expect(rendered).to.exist();
-                expect(rendered).to.contain('Hapi');
+                expect(original).to.exist();
+                expect(original).to.contain('Hapi');
 
-                views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, rendered, config) {
+                views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, cached, cachedConfig) {
 
-                    expect(rendered).to.exist();
-                    expect(rendered).to.contain('Hapi');
+                    expect(cached).to.exist();
+                    expect(cached).to.contain('Hapi');
 
                     expect(gen).to.equal(1);
                     done();
@@ -1444,15 +1444,15 @@ describe('Manager', function () {
                 isCached: false
             });
 
-            views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, rendered, config) {
+            views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, original, originalConfig) {
 
-                expect(rendered).to.exist();
-                expect(rendered).to.contain('Hapi');
+                expect(original).to.exist();
+                expect(original).to.contain('Hapi');
 
-                views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, rendered, config) {
+                views.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, cached, cachedConfig) {
 
-                    expect(rendered).to.exist();
-                    expect(rendered).to.contain('Hapi');
+                    expect(cached).to.exist();
+                    expect(cached).to.contain('Hapi');
 
                     expect(gen).to.equal(2);
                     done();


### PR DESCRIPTION
Lab enabled the [no-shadow rule](http://eslint.org/docs/rules/no-shadow.html)
in hapijs/lab#371 (with exceptions provided by hapijs/lab#379).
This change corrects lint errors created by variable shadowing.