### PR TITLE
Make compilation errors available to extensions.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -266,102 +266,81 @@ internals.Manager.prototype.render = function (filename, context, options, callb
 
     var self = this;
 
-    options = options || {};
-
-    if (this._context) {
-        var base = typeof this._context === 'function' ? this._context() : this._context;
-        if (context) {
-            base = Hoek.shallow(base);
-            var keys = Object.keys(context);
-            for (var i = 0, il = keys.length; i < il; ++i) {
-                var key = keys[i];
-                base[key] = context[key];
-            }
-        }
-
-        context = base;
-    }
-
-    context = context || {};
-
-    var engine = null;
-
-    var fileExtension = Path.extname(filename).slice(1);
-    var extension = fileExtension || this._defaultExtension;
-    if (!extension) {
-        return callback(Boom.badImplementation('Unknown extension and no defaultExtension configured for view template: ' + filename));
-    }
-
-    engine = this._engines[extension];
-    if (!engine) {
-        return callback(Boom.badImplementation('No view engine found for file: ' + filename));
-    }
-
-    var settings = Hoek.applyToDefaults(engine.config, options);
-
-    this._path(filename + (fileExtension ? '' : engine.suffix), settings, false, function (err, templatePath) {
+    this._compileAll(filename, options, function (err, compiled) {
 
         if (err) {
             return callback(err);
         }
 
-        self._compile(templatePath, engine, settings, function (err, compiled) {
+        self._render(compiled, context, function (err, rendered) {
 
             if (err) {
                 return callback(err);
             }
 
+            return callback(null, rendered, compiled.settings);
+        });
+    });
+};
+
+
+internals.Manager.prototype._compileAll = function (template, options, callback) {
+
+    var self = this;
+
+    options = options || {};
+
+    var fileExtension = Path.extname(template).slice(1);
+    var extension = fileExtension || this._defaultExtension;
+    if (!extension) {
+        return callback(Boom.badImplementation('Unknown extension and no defaultExtension configured for view template: ' + template));
+    }
+
+    var engine = this._engines[extension];
+    if (!engine) {
+        return callback(Boom.badImplementation('No view engine found for file: ' + template));
+    }
+
+    var compiled = {
+        settings: Hoek.applyToDefaults(engine.config, options)
+    };
+
+    this._path(template + (fileExtension ? '' : engine.suffix), compiled.settings, false, function (err, templatePath) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        self._compile(templatePath, engine, compiled.settings, function (err, compiledTemplate) {
+
+            if (err) {
+                return callback(err);
+            }
+
+            compiled.template = compiledTemplate;
+
             // No layout
 
-            if (!settings.layout) {
-                compiled(context, settings.runtimeOptions, function (err, rendered) {
-
-                    if (err) {
-                        return callback(Boom.badImplementation(err.message, err));
-                    }
-
-                    return callback(null, rendered, settings);
-                });
-
-                return;
+            if (!compiled.settings.layout) {
+                return callback(null, compiled);
             }
 
             // With layout
 
-            if (context.hasOwnProperty(settings.layoutKeyword)) {
-                return callback(Boom.badImplementation('settings.layoutKeyword conflict', { context: context, keyword: settings.layoutKeyword }));
-            }
-
-            self._path((settings.layout === true ? 'layout' : settings.layout) + engine.suffix, settings, true, function (err, layoutPath) {
+            self._path((compiled.settings.layout === true ? 'layout' : compiled.settings.layout) + engine.suffix, compiled.settings, true, function (err, layoutPath) {
 
                 if (err) {
                     return callback(err);
                 }
 
-                self._compile(layoutPath, engine, settings, function (err, layout) {
+                self._compile(layoutPath, engine, compiled.settings, function (err, layout) {
 
                     if (err) {
                         return callback(err);
                     }
 
-                    compiled(context, settings.runtimeOptions, function (err, renderedContent) {
-
-                        if (err) {
-                            return callback(Boom.badImplementation(err.message, err));
-                        }
-
-                        context[settings.layoutKeyword] = renderedContent;
-                        layout(context, settings.runtimeOptions, function (err, renderedWithLayout) {
-
-                            delete context[settings.layoutKeyword];
-
-                            if (err) {
-                                return callback(Boom.badImplementation(err.message, err));
-                            }
-
-                            return callback(null, renderedWithLayout, settings);
-                        });
-                    });
+                    compiled.layout = layout;
+                    return callback(null, compiled);
                 });
             });
         });
@@ -418,6 +397,59 @@ internals.Manager.prototype._path = function (template, settings, isLayout, next
     function () {
 
         return next(Boom.badImplementation('View file not found: `' + template + '`. Locations searched: [' + paths.join(',') + ']'));
+    });
+};
+
+
+internals.Manager.prototype._render = function (compiled, context, callback) {
+
+    var self = this;
+
+    if (this._context) {
+        var base = typeof this._context === 'function' ? this._context() : this._context;
+        if (context) {
+            base = Hoek.shallow(base);
+            var keys = Object.keys(context);
+            for (var i = 0, il = keys.length; i < il; ++i) {
+                var key = keys[i];
+                base[key] = context[key];
+            }
+        }
+
+        context = base;
+    }
+
+    context = context || {};
+
+    if (context.hasOwnProperty(compiled.settings.layoutKeyword)) {
+        return callback(Boom.badImplementation('settings.layoutKeyword conflict', { context: context, keyword: compiled.settings.layoutKeyword }));
+    }
+
+    compiled.template(context, compiled.settings.runtimeOptions, function (err, renderedContent) {
+
+        if (err) {
+            return callback(Boom.badImplementation(err.message, err));
+        }
+
+        // No layout
+
+        if (!compiled.layout) {
+            return callback(null, renderedContent);
+        }
+
+        // With layout
+
+        context[compiled.settings.layoutKeyword] = renderedContent;
+        compiled.layout(context, compiled.settings.runtimeOptions, function (err, renderedWithLayout) {
+
+            delete context[compiled.settings.layoutKeyword];
+
+            if (err) {
+                return callback(Boom.badImplementation(err.message, err));
+            }
+
+            return callback(null, renderedWithLayout);
+        });
     });
 };
 
@@ -479,7 +511,7 @@ internals.Manager.prototype._response = function (template, context, options, re
         options: options
     };
 
-    return request.generateResponse(source, { variety: 'view', marshal: internals.marshal });
+    return request.generateResponse(source, { variety: 'view', marshal: internals.marshal, prepare: internals.prepare });
 };
 
 
@@ -487,11 +519,13 @@ internals.marshal = function (response, callback) {
 
     var manager = response.source.manager;
 
-    manager.render(response.source.template, response.source.context, response.source.options, function (err, rendered, config) {
+    manager._render(response.source.compiled, response.source.context, function (err, rendered) {
 
         if (err) {
             return callback(err);
         }
+
+        var config = response.source.compiled.settings;
 
         if (!response.headers['content-type']) {
             response.type(config.contentType);
@@ -500,5 +534,20 @@ internals.marshal = function (response, callback) {
         response.encoding(config.encoding);
 
         return callback(null, rendered);
+    });
+};
+
+internals.prepare = function (response, callback) {
+
+    var manager = response.source.manager;
+
+    manager._compileAll(response.source.template, response.source.options, function (err, compiled) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        response.source.compiled = compiled;
+        return callback(response);
     });
 };


### PR DESCRIPTION
Currently neither template compilation nor rendering occur until
after the 'onPreResponse' event. This means that extensions have
no way to intercept template related errors. This change moves the
compilation step to an earlier point in the request lifecycle so
that compilation errors are made available to the 'onPostHandler'
and 'onPreResponse' extension points. Rendering still happens
after 'onPreResponse' so that the context object can be modified
by extensions all the way up through the 'onPreResponse' event.

Fixes #10.