### PR TITLE
Engine initialization.

### DIFF
--- a/examples/nunjucks/index.js
+++ b/examples/nunjucks/index.js
@@ -30,24 +30,27 @@ internals.main = function () {
             throw err;
         }
 
-        var viewPath = Path.join(__dirname, 'templates');
-        var environment = Nunjucks.configure(viewPath, { watch: false });
-
         server.views({
             engines: {
                 html: {
                     compile: function (src, options) {
 
-                        var template = Nunjucks.compile(src, environment);
+                        var template = Nunjucks.compile(src, options.environment);
 
                         return function (context) {
 
                             return template.render(context);
                         };
+                    },
+
+                    prepare: function (options, next) {
+
+                        options.compileOptions.environment = Nunjucks.configure(options.path, { watch: false });
+                        return next();
                     }
                 }
             },
-            path: viewPath
+            path: Path.join(__dirname, 'templates')
         });
 
         server.route({ method: 'GET', path: '/', handler: rootHandler });

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -156,6 +156,9 @@ exports = module.exports = internals.Manager = function (options) {
             engine.cache = {};
         }
 
+        // When a prepare function is provided, state needs to be initialized before trying to compile and render
+        engine.ready = !(engine.module.prepare && typeof engine.module.prepare === 'function');
+
         // Load partials and helpers
 
         self._loadPartials(engine);
@@ -301,11 +304,57 @@ internals.Manager.prototype._prepare = function (template, options, callback) {
         return callback(Boom.badImplementation('No view engine found for file: ' + template));
     }
 
+    template =  template + (fileExtension ? '' : engine.suffix);
+
+    // Engine is ready to render
+
+    if (engine.ready) {
+        return this._prepareTemplates(template, engine, options, callback);
+    }
+
+    // Engine needs initialization
+
+    return this._prepareEngine(engine, function (err) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        return self._prepareTemplates(template, engine, options, callback);
+    });
+};
+
+
+internals.Manager.prototype._prepareEngine = function (engine, next) {
+
+    // _prepareEngine can only be invoked when the prepare function is defined
+
+    try {
+        return engine.module.prepare(engine.config, function (err) {
+
+            if (err) {
+                return next(err);
+            }
+
+            engine.ready = true;
+            return next();
+        });
+    }
+    catch (err) {
+        return next(err);
+    }
+};
+
+
+internals.Manager.prototype._prepareTemplates = function (template, engine, options, callback) {
+
+    var self = this;
+
     var compiled = {
         settings: Hoek.applyToDefaults(engine.config, options)
     };
 
-    this._path(template + (fileExtension ? '' : engine.suffix), compiled.settings, false, function (err, templatePath) {
+    this._path(template, compiled.settings, false, function (err, templatePath) {
 
         if (err) {
             return callback(err);


### PR DESCRIPTION
Some view engines (i.e. Nunjucks) rely on the manager configuration
and other state in order to render templates. This change provides
a convenience method to allow engines to initialize any additional
state and to update the engine configuration accordingly.