### PR TITLE
Failing win tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 0.10
-  - 0.12
-  - iojs
+  - "0.10"
+  - "4.0"
 
+sudo: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2014, Walmart and other contributors.
+Copyright (c) 2012-2015, Walmart and other contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/test/manager.js
+++ b/test/manager.js
@@ -1065,6 +1065,9 @@ describe('Manager', function () {
             testView.render('valid/test', null, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
+                var EOL = Os.EOL;
+                var html = '<!DOCTYPE html>' + EOL + '<html>' + EOL + '    <head>' + EOL + '        <title></title>' + EOL + '    </head>' + EOL + '    <body>' + EOL + '        <div>' + EOL + '    <h1></h1>' + EOL + '</div>' + EOL + EOL + '    </body>' + EOL + '</html>' + EOL;
+                expect(rendered).to.equal(html);
                 done();
             });
         });

--- a/test/manager.js
+++ b/test/manager.js
@@ -580,7 +580,6 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
-                expect(res.result).to.equal('<!DOCTYPE html>\n<html>\n    <head>\n        <title>test</title>\n    </head>\n    <body>\n        <div>\n    <h1>Hapi</h1>\n</div>\n\n    </body>\n</html>\n');
                 done();
             });
         });
@@ -603,7 +602,6 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
-                expect(res.result).to.equal('<!DOCTYPE html>\n<html>\n    <head>\n        <title>test</title>\n    </head>\n    <body>\n        <div>\n    <h1>Hapi</h1>\n</div>\n\n    </body>\n</html>\n');
                 done();
             });
         });
@@ -625,7 +623,6 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
-                expect(res.result).to.equal('test:<div>\n    <h1>Hapi</h1>\n</div>\n');
                 done();
             });
         });
@@ -647,7 +644,6 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
-                expect(res.result).to.equal('test:<div>\n    <h1>Hapi</h1>\n</div>\n');
                 done();
             });
         });
@@ -671,7 +667,6 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
-                expect(res.result).to.equal('test+<div>\n    <h1>Hapi</h1>\n</div>\n');
                 done();
             });
         });
@@ -761,7 +756,6 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
-                expect(res.result).to.equal('<div>\n    <h1>Hapi</h1>\n</div>\n');
                 done();
             });
         });
@@ -1034,7 +1028,6 @@ describe('Manager', function () {
             testView.render('valid/test', null, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
-                expect(rendered).to.equal('<div>\n    <h1></h1>\n</div>\n');
                 done();
             });
         });
@@ -1050,7 +1043,6 @@ describe('Manager', function () {
             testView.render('valid/test', null, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
-                expect(rendered).to.contain('<div>\n    <h1></h1>\n</div>\n');
                 done();
             });
         });
@@ -1168,7 +1160,6 @@ describe('Manager', function () {
             testView.render('valid/test', null, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
-                expect(rendered).to.equal('<div>\n    <h1></h1>\n</div>\n');
                 done();
             });
         });
@@ -1184,7 +1175,6 @@ describe('Manager', function () {
             testView.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
-                expect(rendered).to.equal('<div>\n    <h1>Hapi</h1>\n</div>\n');
                 done();
             });
         });

--- a/test/manager.js
+++ b/test/manager.js
@@ -1,6 +1,7 @@
 // Load modules
 
 var Fs = require('fs');
+var Os = require('os');
 var Code = require('code');
 var Handlebars = require('handlebars');
 var Hapi = require('hapi');
@@ -580,6 +581,9 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
+                var EOL = Os.EOL;
+                var html = '<!DOCTYPE html>' + EOL + '<html>' + EOL + '    <head>' + EOL + '        <title>test</title>' + EOL + '    </head>' + EOL + '    <body>' + EOL + '        <div>' + EOL + '    <h1>Hapi</h1>' + EOL + '</div>' + EOL + EOL + '    </body>' + EOL + '</html>' + EOL;
+                expect(res.result).to.equal(html);
                 done();
             });
         });
@@ -602,6 +606,9 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
+                var EOL = Os.EOL;
+                var html = '<!DOCTYPE html>' + EOL + '<html>' + EOL + '    <head>' + EOL + '        <title>test</title>' + EOL + '    </head>' + EOL + '    <body>' + EOL + '        <div>' + EOL + '    <h1>Hapi</h1>' + EOL + '</div>' + EOL + EOL + '    </body>' + EOL + '</html>' + EOL;
+                expect(res.result).to.equal(html);
                 done();
             });
         });
@@ -623,6 +630,9 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
+                var EOL = Os.EOL;
+                var html = 'test:<div>' + EOL + '    <h1>Hapi</h1>' + EOL + '</div>' + EOL;
+                expect(res.result).to.equal(html);
                 done();
             });
         });
@@ -644,6 +654,9 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
+                var EOL = Os.EOL;
+                var html = 'test:<div>' + EOL + '    <h1>Hapi</h1>' + EOL + '</div>' + EOL;
+                expect(res.result).to.equal(html);
                 done();
             });
         });
@@ -667,6 +680,9 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
+                var EOL = Os.EOL;
+                var html = 'test+<div>' + EOL + '    <h1>Hapi</h1>' + EOL + '</div>' + EOL;
+                expect(res.result).to.equal(html);
                 done();
             });
         });
@@ -756,6 +772,9 @@ describe('Manager', function () {
 
                 expect(res.result).to.exist();
                 expect(res.statusCode).to.equal(200);
+                var EOL = Os.EOL;
+                var html = '<div>' + EOL + '    <h1>Hapi</h1>' + EOL + '</div>' + EOL;
+                expect(res.result).to.equal(html);
                 done();
             });
         });
@@ -1028,6 +1047,9 @@ describe('Manager', function () {
             testView.render('valid/test', null, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
+                var EOL = Os.EOL;
+                var html = '<div>' + EOL + '    <h1></h1>' + EOL + '</div>' + EOL;
+                expect(rendered).to.equal(html);
                 done();
             });
         });
@@ -1160,6 +1182,9 @@ describe('Manager', function () {
             testView.render('valid/test', null, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
+                var EOL = Os.EOL;
+                var html = '<div>' + EOL + '    <h1></h1>' + EOL + '</div>' + EOL;
+                expect(rendered).to.equal(html);
                 done();
             });
         });
@@ -1175,6 +1200,9 @@ describe('Manager', function () {
             testView.render('valid/test', { title: 'test', message: 'Hapi' }, null, function (err, rendered, config) {
 
                 expect(rendered).to.exist();
+                var EOL = Os.EOL;
+                var html = '<div>' + EOL + '    <h1>Hapi</h1>' + EOL + '</div>' + EOL;
+                expect(rendered).to.equal(html);
                 done();
             });
         });


### PR DESCRIPTION
Hi

When running tests of hapi on windows last night I found an issue here https://github.com/hapijs/hapi/blob/master/test/connection.js#L1089-L1118 related to vision.  I have removed string comparisons of rendered html in failing tests due to EOL issue.  The only test I couldn't fix on windows is this one https://github.com/hapijs/vision/blob/master/test/manager.js#L1307-L1330 as it uses chmodSync.  Unfortunately I cannot fix the root cause of issue as I cannot see where new lines are created for rendered object.

Thanks
Simon