### PR TITLE
Update plugin attributes.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,8 @@ exports.register = function (server, pluginOptions, next) {
 };
 
 exports.register.attributes = {
+    connections: false,
+    once: true,
     pkg: require('../package.json')
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -635,3 +635,54 @@ describe('views()', () => {
         done();
     });
 });
+
+describe('Plugin', () => {
+
+    it('can be registered before connections', (done) => {
+
+        const plugin = function (server, options, next) {
+
+            server.dependency('vision');
+            server.connection();
+            next();
+        };
+
+        plugin.attributes = {
+            connections: false,
+            name: 'test'
+        };
+
+        const server = new Hapi.Server();
+        server.register([Vision, plugin], Hoek.ignore);
+
+        expect(server.views).to.be.a.function();
+        server.initialize((err) => {
+
+            expect(err).to.not.exist();
+            server.stop(done);
+        });
+    });
+
+    it('only registers once', (done) => {
+
+        const one = function (server, options, next) {
+
+            server.register(Vision, next);
+        };
+
+        const two = function (server, options, next) {
+
+            server.register(Vision, next);
+        };
+
+        one.attributes = { name: 'one' };
+        two.attributes = { name: 'two' };
+
+        const server = new Hapi.Server();
+        server.register([one, two], (err) => {
+
+            expect(err).to.not.exist();
+            done();
+        });
+    });
+});


### PR DESCRIPTION
In some use cases it may make sense to load vision before any
connections have been configured. Similarly, multiple plugins in an
application may try to load vision. Since vision only deals with
template rendering, it is possible to do both of these if the
'connections' and 'once' attributes are provided in the plugin
attributes.

Resolves #63.