### PR TITLE
Promises

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,9 +7,9 @@ are augmented as follows:
 
 - [Server](#server)
     - [`server.views(options)`](#serverviewsoptions)
-    - [`server.render(template, context, [options], callback)`](#serverrendertemplate-context-options-callback)
+    - [`server.render(template, context, [options], [callback])`](#serverrendertemplate-context-options-callback)
 - [Requests](#requests)
-    - [`request.render(template, context, [options], callback)`](#requestrendertemplate-context-options-callback)
+    - [`request.render(template, context, [options], [callback])`](#requestrendertemplate-context-options-callback)
     - [The `view` handler](#the-view-handler)
 - [Reply interface](#reply-interface)
     - [`reply.view(template, [context, [options]])`](#replyviewtemplate-context-options)
@@ -104,7 +104,7 @@ methods.
 
 `server.views()` returns a [view manager](#view-manager) that can be used to programmatically manipulate the engine configuration.
 
-### `server.render(template, context, [options], callback)`
+### `server.render(template, context, [options], [callback])`
 
 Utilizes the server views manager to render a template where:
 - `template` - the template filename and path, relative to the views manager templates path (`path`
@@ -116,6 +116,9 @@ Utilizes the server views manager to render a template where:
     - `err` - the rendering error if any.
     - `rendered` - the result view string.
     - `config` - the configuration used to render the template.
+
+If no `callback` is provided, a `Promise` object is returned. The returned promise is resolved with only the
+rendered content an not the configuration object.
 
 ```js
 const Hapi = require('hapi');
@@ -147,7 +150,7 @@ server.register(require('vision'), (err) => {
 
 ## [Requests](https://github.com/hapijs/hapi/blob/master/API.md#requests)
 
-### `request.render(template, context, [options], callback)`
+### `request.render(template, context, [options], [callback])`
 
 `request.render()` works the same way as [`server.render()`](#serverrendertemplate-context-options-callback)
 but is for use inside of request handlers. [`server.render()`](#serverrendertemplate-context-options-callback)
@@ -307,12 +310,12 @@ server.register(require('vision'), (err) => {
 </html>
 ```
 
-# View Manager
+## View Manager
 
 ## `manager.registerHelper(name, helper)`
 
 Registers a helper, on all configured engines that have a `registerHelper()` method, for use during template rendering. Engines without a `registerHelper()` method will be skipped. The `name` is the name that templates should use to reference the helper and `helper` is the function that will be invoked when the helper is called.
 
-## `manager.render(template, context, options, callback)`
+## `manager.render(template, context, options, [callback])`
 
 Renders a template. This is typically not needed and it is usually more convenient to use [`server.render()`](#serverrendertemplate-context-options-callback).

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,8 +66,10 @@ exports.register.attributes = {
 
 internals.render = function (template, context, options, callback) {
 
-    callback = (typeof callback === 'function' ? callback : options);
-    options = (options === callback ? {} : options);
+    if (!callback && typeof options === 'function') {
+        callback = options;
+        options = {};
+    }
 
     const isServer = (typeof this.route === 'function');
     const server = (isServer ? this : this.server);

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -279,6 +279,10 @@ internals.Manager.prototype.registerHelper = function (name, helper) {
 
 internals.Manager.prototype.render = function (filename, context, options, callback) {
 
+    if (!callback) {
+        return internals._wrapMethod(this, this.render, [filename, context, options]);
+    }
+
     this._prepare(filename, options, (err, compiled) => {
 
         if (err) {
@@ -602,5 +606,22 @@ internals.prepare = function (response, callback) {
 
         response.source.compiled = compiled;
         return callback(response);
+    });
+};
+
+internals._wrapMethod = (bind, method, args) => {
+
+    return new Promise((resolve, reject) => {
+
+        const callback = function (err, result) {
+
+            if (err) {
+                return reject(err);
+            }
+
+            return resolve(result);
+        };
+
+        method.apply(bind, args.concat(callback));
     });
 };

--- a/test/index.js
+++ b/test/index.js
@@ -483,6 +483,88 @@ describe('render()', () => {
             });
         });
     });
+
+    it('returns a promise when no options or callback given (server)', () => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register(Vision, Hoek.ignore);
+
+        server.views({
+            engines: { html: Handlebars },
+            path: __dirname + '/templates/valid'
+        });
+
+        return server.render('test', { message: 'Hello!' })
+        .then((content) => expect(content).to.contain('<h1>Hello!</h1>'));
+    });
+
+    it('returns a promise when no callback given (server)', () => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register(Vision, Hoek.ignore);
+
+        server.views({
+            engines: { html: Handlebars },
+            path: __dirname + '/templates/valid'
+        });
+
+        return server.render('test', { message: 'Hello!' }, {})
+        .then((content) => expect(content).to.contain('<h1>Hello!</h1>'));
+    });
+
+    it('returns a promise when no options or callback given (request)', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register(Vision, Hoek.ignore);
+
+        server.views({
+            engines: { html: Handlebars },
+            path: __dirname + '/templates/valid'
+        });
+
+        const handler = (request, reply) => {
+
+            const promise = request.render('test', { message: 'Hello!' });
+            expect(promise).to.be.an.instanceof(Promise);
+            reply(promise);
+        };
+
+        server.route({ method: 'GET', path: '/', handler: handler });
+        server.inject({ method: 'GET', url: '/' }, (response) => {
+
+            expect(response.result).to.contain('<h1>Hello!</h1>');
+            done();
+        });
+    });
+
+    it('returns a promise when no callback given (request)', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register(Vision, Hoek.ignore);
+
+        server.views({
+            engines: { html: Handlebars },
+            path: __dirname + '/templates/valid'
+        });
+
+        const handler = (request, reply) => {
+
+            const promise = request.render('test', { message: 'Hello!' }, {});
+            expect(promise).to.be.an.instanceof(Promise);
+            reply(promise);
+        };
+
+        server.route({ method: 'GET', path: '/', handler: handler });
+        server.inject({ method: 'GET', url: '/' }, (response) => {
+
+            expect(response.result).to.contain('<h1>Hello!</h1>');
+            done();
+        });
+    });
 });
 
 describe('views()', () => {

--- a/test/manager.js
+++ b/test/manager.js
@@ -1919,6 +1919,41 @@ describe('Manager', () => {
                 });
             });
         });
+
+        it('returns a promise that is resolved with the content if no callback is provided', () => {
+
+            const views = new Manager({
+                engines: { html: { module: Handlebars } },
+                path: __dirname + '/templates/valid'
+            });
+
+            return views.render('test', { message: 'Hello!' }, null)
+            .then((content) => {
+
+                expect(content).to.contain('<h1>Hello!</h1>');
+            });
+        });
+
+        it('returns a promise that is rejected on error if no callback is provided', () => {
+
+            const views = new Manager({
+                engines: { html: { module: Handlebars } },
+                path: __dirname + '/templates/valid'
+            });
+
+            return views.render('missing', null, null)
+            .then(
+                () => {
+
+                    throw new Error('should not resolve');
+                },
+                (err) => {
+
+                    expect(err).to.exist();
+                    expect(err.message).to.contain('missing.html');
+                }
+            );
+        });
     });
 
     describe('_response()', () => {


### PR DESCRIPTION
This change makes callbacks optional for the render methods. When
callbacks are not provided, promises are returns from the methods.