### PR TITLE
Use `Path.isAbsolute` instead of Hoek helper method

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -238,7 +238,7 @@ internals.Manager.prototype._loadHelpers = function (engine) {
     helpersPaths.forEach((helpersPath) => {
 
         let path = internals.path(engine.config.relativeTo, helpersPath);
-        if (!Hoek.isAbsolutePath(path)) {
+        if (!Path.isAbsolute(path)) {
             path = Path.join(process.cwd(), path);
         }
 
@@ -413,7 +413,7 @@ internals.Manager.prototype._path = function (template, settings, isLayout, next
 
     // Validate path
 
-    const isAbsolutePath = Hoek.isAbsolutePath(template);
+    const isAbsolutePath = Path.isAbsolute(template);
     const isInsecurePath = template.match(/\.\.\//g);
 
     if (!settings.allowAbsolutePaths &&
@@ -516,7 +516,7 @@ internals.Manager.prototype._render = function (compiled, context, request, call
 internals.path = function (base, path, file) {
 
     if (path &&
-        Hoek.isAbsolutePath(path)) {
+        Path.isAbsolute(path)) {
 
         return Path.join(path, file || '');
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "boom": "3.x.x",
-    "hoek": "3.x.x",
+    "hoek": "4.x.x",
     "items": "2.x.x",
     "joi": "8.x.x"
   },


### PR DESCRIPTION
hoek@4.0.0 removed `Hoek.isAbsolutePath`, as `Path.isAbsolute` is available
on supported Node.js versions.