### PR TITLE
Attempt to allow setting up view manager during plugin registration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,10 @@ exports.register = function (server, pluginOptions, next) {
         return this.response(realm.manager._response(template, context, options, this.request));
     });
 
+    if (Object.keys(pluginOptions).length) {
+        server.views(pluginOptions);
+    }
+
     return next();
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -901,4 +901,30 @@ describe('Plugin', () => {
             done();
         });
     });
+
+    it('runs views() with pluginOptions', (done) => {
+
+        const plugins = {
+            register: Vision,
+            options: {
+                engines: { html: require('handlebars') },
+                path: __dirname + '/templates'
+            }
+        };
+        const server = new Hapi.Server();
+        server.connection();
+        server.register(plugins, Hoek.ignore);
+
+        server.route({ method: 'GET', path: '/{param}', handler: { view: 'valid/handler' } });
+        server.inject({
+            method: 'GET',
+            url: '/hello'
+        }, (res) => {
+
+            expect(res.result).to.contain('hello');
+            done();
+        });
+
+
+    });
 });


### PR DESCRIPTION
Perhaps I'm missing something, but it seems odd to make a separate call to `server.views()` to setup the view manager. Why not pass in the options when registering the vision plugin? Like so:

```
server.register({
  register: require('vision'),
  options: {
    engines: { html: require('handlebars') },
    path: __dirname + '/templates'
  });
```

This PR is an attempt to make the above work if options are passed in. However, I'm running into an issue with realms. I can't figure out why the manager is not available on the realm when trying to render a view. From my perspective, this seems like a possible bug in hapi, but I haven't been able to trace it through to prove that. 

Any insights as to the origin of the issue I'm experiencing? 
