### PR TITLE
upgrade to joi 9.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "boom": "3.x.x",
     "hoek": "4.x.x",
     "items": "2.x.x",
-    "joi": "8.x.x"
+    "joi": "9.x.x"
   },
   "devDependencies": {
     "babel-core": "6.x.x",


### PR DESCRIPTION
FYI - this is blocking our upgrade to hapi 15.x. Thanks, L

```
> vision@4.1.0 test /private/tmp/vision
> lab -a code -t 100 -L



  ..................................................
  ..................................................
  ...................

119 tests complete
Test duration: 640 ms
Assertions count: 288 (verbosity: 2.42)
No global variable leaks detected
Coverage: 100.00%
Linting results: No issues
```