### PR TITLE
Adds an Option to Override View Manager

### DIFF
--- a/API.md
+++ b/API.md
@@ -85,6 +85,8 @@ Initializes the server views manager where:
     - `allowInsecureAccess` - if set to `true`, allows template paths passed to
       [`reply.view()`](https://github.com/hapijs/hapi/blob/master/API.md#replyviewtemplate-context-options)
       to contain '../'. Defaults to `false`.
+    - `allowManagerOverride` - if set to `true`, allows view manager options to be overridden by subsequent
+      calls. Useful for dynamic view path configurations that may vary per request. Defaults to `false`.
     - `compileOptions` - options object passed to the engine's compile function. Defaults to empty
       options `{}`.
     - `runtimeOptions` - options object passed to the returned function from the compile operation.

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,9 @@ exports.register = function (server, pluginOptions, next) {
 
         Hoek.assert(options, 'Missing views options');
         this.realm.plugins.vision = this.realm.plugins.vision || {};
-        Hoek.assert(!this.realm.plugins.vision.manager, 'Cannot set views manager more than once');
+        if (!options.allowManagerOverride) {
+            Hoek.assert(!this.realm.plugins.vision.manager, 'Cannot set views manager more than once');
+        }
 
         if (!options.relativeTo &&
             this.realm.settings.files.relativeTo) {

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -27,6 +27,7 @@ internals.defaults = {
     isCached: true,
     allowAbsolutePaths: false,
     allowInsecureAccess: false,
+    allowManagerOverride: false,
     // partialsPath: '',
     contentType: 'text/html',
     compileMode: 'sync',
@@ -48,6 +49,7 @@ internals.schema.viewOverride = Joi.object({
     encoding: Joi.string(),
     allowAbsolutePaths: Joi.boolean(),
     allowInsecureAccess: Joi.boolean(),
+    allowManagerOverride: Joi.boolean(),
     contentType: Joi.string()
 });
 


### PR DESCRIPTION
hapijs/vision, interested in your opinion(s) on this one. The use case is for a multi-domain/website content management system that allows for dynamically stacked website and theme storage paths that can vary per request. Within the system's user interface website storage, theme storage and assigned website theme are each configureable per domain. 

For example, initial load for `domain.com` serves templates from a `/themes/abc` with a fall back of `/disk1/domain.com` directory while next request may need to target `/themes/xyz` with a fall back of `/disk2/domain.com`

Currently this doesn't seem possible to do, because if you try to setup the view manager using an `onRequest` server extension the view manager will throw with `Cannot set views manager more than once` on subsequent requests. Since the system can be serving many different departmental websites across an organization restarting the server to pickup path changes for a single website doesn't feel like a great option.

I understand not being able to _register_ the plugin more than once, but not why the view manager options can't be changed after initialized. Is there a reason that I'm not seeing which prevents this from being doable? I've been using this new option for a couple weeks with dustjs and it's been working alright for me.

Is `allowManagerOverride` a good name? Thoughts? 

I used the existing templates to demonstrate the functionality in the tests. First request will use `/test/templates/valid` as the base path and second request will change it to`/test/templates/layout` feedback on those are welcome too please.