### PR TITLE
[WIP] Automatically enable caching based on NODE_ENV

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -24,7 +24,7 @@ internals.defaults = {
     layout: false,
     layoutKeyword: 'content',
     encoding: 'utf8',
-    isCached: true,
+    isCached: (process.env.NODE_ENV === 'production'),
     allowAbsolutePaths: false,
     allowInsecureAccess: false,
     // partialsPath: '',


### PR DESCRIPTION
I like that [Express enables the view cache by default on production](https://github.com/expressjs/express/blob/4.14.0/lib/application.js#L117-L119). I figured that this would be a sane default for hapi, too.

If you are in favor of this change, I can update the tests next.