### PR TITLE
Load partials and helpers before compile if isCached is false

### DIFF
--- a/examples/handlebars/helpers.js
+++ b/examples/handlebars/helpers.js
@@ -41,7 +41,8 @@ internals.main = async () => {
         engines: { html: Handlebars },
         relativeTo: __dirname,
         path: `templates/${internals.templatePath}`,
-        helpersPath: `templates/${internals.templatePath}/helpers`
+        helpersPath: `templates/${internals.templatePath}/helpers`,
+        isCached: false
     });
 
     server.route({ method: 'GET', path: '/', handler: rootHandler });

--- a/examples/handlebars/partials.js
+++ b/examples/handlebars/partials.js
@@ -39,7 +39,8 @@ internals.main = async () => {
         engines: { html: Handlebars },
         relativeTo: __dirname,
         path: 'templates/withPartials',
-        partialsPath: 'templates/withPartials/partials'
+        partialsPath: 'templates/withPartials/partials',
+        isCached: false
     });
 
     server.route({ method: 'GET', path: '/', handler: rootHandler });

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -254,6 +254,10 @@ internals.Manager.prototype._loadHelpers = function (engine) {
             }
 
             try {
+                if (!engine.config.isCached) {
+                    delete require.cache[require.resolve(file)]; // bust require's cache
+                }
+
                 const helper = require(file);
                 if (typeof helper === 'function') {
                     const offset = path.slice(-1) === Path.sep ? 0 : 1;

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -375,6 +375,11 @@ internals.Manager.prototype._prepareTemplates = function (template, engine, opti
             return callback(err);
         }
 
+        if (!engine.config.isCached) {
+            this._loadPartials(engine);
+            this._loadHelpers(engine);
+        }
+
         this._compile(templatePath, engine, compiled.settings, (err, compiledTemplate) => {
 
             if (err) {
@@ -537,7 +542,7 @@ internals.Manager.prototype._compile = function (template, engine, settings, cal
         return callback(null, engine.cache[template]);
     }
 
-    settings.compileOptions.filename = template;            // Pass the template to Jade via this copy of compileOptions
+    settings.compileOptions.filename = template;            // Pass the template to Pug via this copy of compileOptions
 
     // Read file
 

--- a/test/manager.js
+++ b/test/manager.js
@@ -1565,7 +1565,8 @@ describe('Manager', () => {
                             }
                         }
                     }
-                }
+                },
+                isCached: true // isCached defaults to `true`
             });
 
             const original = await views.render('valid/test', { title: 'test', message: 'Hapi' });
@@ -1609,11 +1610,88 @@ describe('Manager', () => {
             expect(original).to.exist();
             expect(original).to.contain('Hapi');
 
-            const cached = await views.render('valid/test', { title: 'test', message: 'Hapi' });
-            expect(cached).to.exist();
-            expect(cached).to.contain('Hapi');
+            const notCached = await views.render('valid/test', { title: 'test', message: 'Hapi' });
+            expect(notCached).to.exist();
+            expect(notCached).to.contain('Hapi');
 
             expect(gen).to.equal(2);
+        });
+
+        it('recompiles partials/helpers when caching is disabled', async () => {
+
+            const partialsPath = __dirname + '/templates/valid/partials';
+            const helpersPath = __dirname + '/templates/valid/helpers';
+
+            const originalPartialVal = '<nav>Nav</nav>';
+            const originalNestedPartialVal = '<nav>Nested</nav>';
+            const originalHelperVal = '\'use strict\';\n\nexports = module.exports = function (context) {\n\n    return context.toUpperCase();\n};\n';
+
+            const mutateToUppercaseVal = 'i want to be uppercase';
+
+            const resetMutatedValues = () => {
+
+                return new Promise((resolve, reject) => {
+
+                    Fs.writeFileSync(partialsPath + '/navToMutate.html', originalPartialVal);
+                    Fs.writeFileSync(partialsPath + '/nested/navToMutate.html', originalNestedPartialVal);
+                    Fs.writeFileSync(helpersPath + '/uppercaseToMutate.js', originalHelperVal);
+
+                    return resolve();
+                });
+            };
+
+            // Set everything correct to start in case a failed test leaves
+            // these in a mutated state
+
+            await resetMutatedValues();
+
+            const views = new Manager({
+                path: __dirname + '/templates/valid',
+                partialsPath,
+                helpersPath,
+                engines: {
+                    html: Handlebars
+                },
+                isCached: false
+            });
+
+            const originalPartialAndHelperValues = ' Nav:<nav>Nav</nav>|<nav>Nested</nav>\n<p>This is all I WANT TO BE UPPERCASE and this is how we like it!</p>';
+
+            const original = await views.render('testHelpersAndPartials', {
+                mutateToUppercase: mutateToUppercaseVal
+            });
+
+            expect(original).to.exist();
+            expect(original).to.equal(originalPartialAndHelperValues);
+
+            // Mutate the partials here
+
+            Fs.writeFileSync(partialsPath + '/navToMutate.html', '<nav>N4v With Changes</nav>');
+            Fs.writeFileSync(partialsPath + '/nested/navToMutate.html', '<nav>N3st3d With Changes</nav>');
+
+            // Mutate the helpers here
+
+            Fs.writeFileSync(helpersPath + '/uppercaseToMutate.js', '\'use strict\';\n\nexports = module.exports = function (context) {\n\n    return context.toUpperCase().split(\'\').sort().join(\'\').trim();\n};\n');
+
+            const mutatedPartialsAndHelper = await views.render('testHelpersAndPartials', {
+                mutateToUppercase: mutateToUppercaseVal
+            });
+
+            expect(mutatedPartialsAndHelper).to.exist();
+
+            expect(mutatedPartialsAndHelper).to.equal(' Nav:<nav>N4v With Changes</nav>|<nav>N3st3d With Changes</nav>\n<p>This is all AABCEEEINOPPRSTTUW and this is how we like it!</p>');
+
+            // Revert the mutations
+
+            await resetMutatedValues();
+
+            // Verify they've reverted correctly
+
+            const changedBack = await views.render('testHelpersAndPartials', {
+                mutateToUppercase: mutateToUppercaseVal
+            });
+
+            expect(changedBack).to.equal(originalPartialAndHelperValues);
         });
     });
 

--- a/test/templates/valid/helpers/uppercaseToMutate.js
+++ b/test/templates/valid/helpers/uppercaseToMutate.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports = module.exports = function (context) {
+
+    return context.toUpperCase();
+};

--- a/test/templates/valid/partials/navToMutate.html
+++ b/test/templates/valid/partials/navToMutate.html
@@ -1,0 +1,1 @@
+<nav>Nav</nav>

--- a/test/templates/valid/partials/nested/navToMutate.html
+++ b/test/templates/valid/partials/nested/navToMutate.html
@@ -1,0 +1,1 @@
+<nav>Nested</nav>

--- a/test/templates/valid/testHelpersAndPartials.html
+++ b/test/templates/valid/testHelpersAndPartials.html
@@ -1,0 +1,2 @@
+ Nav:{{> navToMutate}}|{{> nested/navToMutate}}
+<p>This is all {{uppercaseToMutate this.mutateToUppercase}} and this is {{long "how"}} we like it!</p>


### PR DESCRIPTION
Why this change? If isCached is false, then users expect there to be changes when the file on disk changes. Build tools like `BrowserSync` also reload when files on disk change, so this adds a lot of 'it just works' value

Feedback welcome!