### PR TITLE
Pass manager options at registration time

### DIFF
--- a/API.md
+++ b/API.md
@@ -3,7 +3,6 @@
 Most interaction with **vision** is done via the `h` [response toolkit](https://github.com/hapijs/hapi/blob/master/API.md#response-toolkit)
 and [server](https://github.com/hapijs/hapi/blob/master/API.md#server) interfaces.
 
-## TOC
 - [Registration](#registration)
 - [View Manager](#view-manager)
   - [`options`](#options)

--- a/API.md
+++ b/API.md
@@ -1,10 +1,14 @@
 # API Reference
 
-Most interaction with **vision** is done via the [server](https://github.com/hapijs/hapi/blob/master/API.md#server)
-and the `h` response [toolkit](https://github.com/hapijs/hapi/blob/master/API.md#response-toolkit) interfaces. When the
-**vision** plugin is registered, the base [hapi APIs](https://github.com/hapijs/hapi/blob/master/API.md)
-are augmented as follows:
+Most interaction with **vision** is done via the `h` [response toolkit](https://github.com/hapijs/hapi/blob/master/API.md#response-toolkit)
+and [server](https://github.com/hapijs/hapi/blob/master/API.md#server) interfaces.
 
+## TOC
+- [Registration](#registration)
+- [View Manager](#view-manager)
+  - [`options`](#options)
+  - [`manager.registerHelper(name, helper)`](#managerregisterhelpername-helper)
+  - [`manager.render(template, context, options, callback)`](#managerrendertemplate-context-options-callback)
 - [Server](#server)
   - [`server.views(options)`](#serverviewsoptions)
   - [`server.render(template, context, [options], [callback])`](#serverrendertemplate-context-options-callback)
@@ -13,105 +17,137 @@ are augmented as follows:
   - [The `view` handler](#the-view-handler)
 - [`h` response toolkit interface](#response-toolkit-interface)
   - [`h.view(template, [context], [options]])`](#hviewtemplate-context-options)
-- [View Manager](#view-manager)
-  - [`manager.registerHelper(name, helper)`](#managerregisterhelpername-helper)
-  - [`manager.render(template, context, options, callback)`](#managerrendertemplate-context-options-callback)
+
+## Registration
+
+Vision can be registered multiple times and receives [`view manager options`](#options) as registration options.
+
+Example:
+```
+internals.provision = async () => {
+
+    await server.register({
+        plugin: require('vision'),
+        options: {
+            engines: { html: require('handlebars') },
+            path: __dirname + '/templates'
+        }
+    })
+
+    const context = {
+        title: 'Registration Example',
+        message: 'Hello, World'
+    };
+
+    return server.render('hello', context);
+};
+
+internals.provision();
+```
+
+## View Manager
+
+The View Manager is configured with [`registration options`](#registration) or by calling [`server.views(options)`](#serverviewsoptions)
+
+## `options`
+  - `engines` - required object where each key is a file extension (e.g. 'html', 'hbr'), mapped
+    to the npm module used for rendering the templates. Alternatively, the extension can be
+    mapped to an object with the following options:
+      - `module` - the npm module used for rendering the templates. The module object must
+        contain the `compile()` function:
+          - `compile()` - the rendering function. The required function signature depends on the
+            `compileMode` settings (see below). If `compileMode` is `'sync'`, the signature is
+            `compile(template, options)`, the return value is a function with signature
+            `function(context, options)` (the compiled sync template), and the method is allowed to throw errors. If
+            `compileMode` is `'async'`, the signature is `compile(template, options, next)`
+            where `next` has the signature `function(err, compiled)`, `compiled` is a
+            function with signature `function(context, options, callback)` (the compiled async template) and `callback` has the
+            signature `function(err, rendered)`.
+          - `prepare(config, next)` - initializes additional engine state.
+            The `config` object is the engine configuration object allowing updates to be made.
+            This is useful for engines like Nunjucks that rely on additional state for rendering.
+            `next` has the signature `function(err)`.
+          - `registerPartial(name, src)` - registers a partial for use during template rendering.
+            The `name` is the partial path that templates should use to reference the partial and
+            `src` is the uncompiled template string for the partial.
+          - `registerHelper(name, helper)` - registers a helper for use during template rendering.
+            The `name` is the name that templates should use to reference the helper and `helper`
+            is the function that will be invoked when the helper is called.
+      - any of the `views` options listed below (except `defaultExtension`) to override the
+        defaults for a specific engine.
+
+  - `compileMode` - specify whether the engine `compile()` method is `'sync'` or `'async'`.
+    Defaults to `'sync'`.
+  - `defaultExtension` - defines the default filename extension to append to template names when
+    multiple engines are configured and not explicit extension is provided for a given template.
+    No default value.
+  - `path` - the root file path, or array of file paths, used to resolve and load the templates identified when calling
+    [`h.view()`](#hviewtemplate-context-options).
+    Defaults to current working directory.
+  - `partialsPath` - the root file path, or array of file paths, where partials are located. Partials are small segments
+    of template code that can be nested and reused throughout other templates. Defaults to no
+    partials support (empty path).
+  - `helpersPath` - the directory path, or array of directory paths, where helpers are located. Helpers are functions used
+    within templates to perform transformations and other data manipulations using the template
+    context or other inputs. Each valid template file in the helpers directory is loaded and the file name
+    is used as the helper name. The files must export a single method with the signature
+    `function(context)` and return a string. Sub-folders are not supported and are ignored.
+    Defaults to no helpers support (empty path). Note that pug does not support loading helpers
+    this way.
+  - `relativeTo` - a base path used as prefix for `path` and `partialsPath`. No default.
+  - `layout` - if set to `true` or a layout filename, layout support is enabled. A layout is a
+    single template file used as the parent template for other view templates in the same engine.
+    If `true`, the layout template name must be 'layout.ext' where 'ext' is the engine's
+    extension. Otherwise, the provided filename is suffixed with the engine's extension and
+    loaded. Disable `layout` when using Jade as it will handle including any layout files
+    independently. Defaults to `false`.
+  - `layoutPath` - the root file path, or array of file paths, where layout templates are located (using the `relativeTo`
+    prefix if present). Defaults to `path`.
+  - `layoutKeyword` - the key used by the template engine to denote where primary template
+    content should go. Defaults to `'content'`.
+  - `encoding` - the text encoding used by the templates when reading the files and outputting
+    the result. Defaults to `'utf8'`.
+  - `isCached` - if set to `false`, templates will not be cached (thus will be read from file on
+    every use). Defaults to `true`.
+  - `allowAbsolutePaths` - if set to `true`, allows absolute template paths passed to
+    [`h.view()`](#hviewtemplate-context-options).
+    Defaults to `false`.
+  - `allowInsecureAccess` - if set to `true`, allows template paths passed to
+    [`h.view()`](#hviewtemplate-context-options)
+    to contain '../'. Defaults to `false`.
+  - `compileOptions` - options object passed to the engine's compile function. Defaults to empty
+    options `{}`.
+  - `runtimeOptions` - options object passed to the returned function from the compile operation.
+    Defaults to empty options `{}`.
+  - `contentType` - the content type of the engine results. Defaults to `'text/html'`.
+  - `context` - a global context used with all templates. The global context option can be either
+    an object or a function that takes the [`request`](https://github.com/hapijs/hapi/blob/master/API.md#request)
+    as its only argument and returns a context object. The [`request`](https://github.com/hapijs/hapi/blob/master/API.md#request) object is only provided when using
+    the [view handler](#the-view-handler) or [`h.view()`](#hviewtemplate-context-options). When using
+    [`server.render()`](#serverrendertemplate-context-options-callback) or
+    [`request.render()`](#requestrendertemplate-context-options-callback), the [`request`](https://github.com/hapijs/hapi/blob/master/API.md#request) argument will be `null`. When rendering
+    views, the global context will be merged with any context object specified on the handler or using
+    [`h.view()`](#hviewtemplate-context-options). When multiple context objects are used, values from the global
+    context always have lowest precedence.
+
+## `manager.registerHelper(name, helper)`
+
+Registers a helper, on all configured engines that have a `registerHelper()` method, for use during template rendering. Engines without a `registerHelper()` method will be skipped. The `name` is the name that templates should use to reference the helper and `helper` is the function that will be invoked when the helper is called.
+
+## `manager.render(template, context, options, [callback])`
+
+Renders a template. This is typically not needed and it is usually more convenient to use [`server.render()`](#serverrendertemplate-context-options-callback).
 
 ## [Server](https://github.com/hapijs/hapi/blob/master/API.md#server)
 
 ### `server.views(options)`
 
-Initializes the server views manager where:
-- `options` - a configuration object with the following:
-    - `engines` - required object where each key is a file extension (e.g. 'html', 'hbr'), mapped
-      to the npm module used for rendering the templates. Alternatively, the extension can be
-      mapped to an object with the following options:
-        - `module` - the npm module used for rendering the templates. The module object must
-          contain the `compile()` function:
-            - `compile()` - the rendering function. The required function signature depends on the
-              `compileMode` settings (see below). If `compileMode` is `'sync'`, the signature is
-              `compile(template, options)`, the return value is a function with signature
-              `function(context, options)` (the compiled sync template), and the method is allowed to throw errors. If
-              `compileMode` is `'async'`, the signature is `compile(template, options, next)`
-              where `next` has the signature `function(err, compiled)`, `compiled` is a
-              function with signature `function(context, options, callback)` (the compiled async template) and `callback` has the
-              signature `function(err, rendered)`.
-            - `prepare(config, next)` - initializes additional engine state.
-              The `config` object is the engine configuration object allowing updates to be made.
-              This is useful for engines like Nunjucks that rely on additional state for rendering.
-              `next` has the signature `function(err)`.
-            - `registerPartial(name, src)` - registers a partial for use during template rendering.
-              The `name` is the partial path that templates should use to reference the partial and
-              `src` is the uncompiled template string for the partial.
-            - `registerHelper(name, helper)` - registers a helper for use during template rendering.
-              The `name` is the name that templates should use to reference the helper and `helper`
-              is the function that will be invoked when the helper is called.
-        - any of the `views` options listed below (except `defaultExtension`) to override the
-          defaults for a specific engine.
-
-    - `compileMode` - specify whether the engine `compile()` method is `'sync'` or `'async'`.
-      Defaults to `'sync'`.
-    - `defaultExtension` - defines the default filename extension to append to template names when
-      multiple engines are configured and not explicit extension is provided for a given template.
-      No default value.
-    - `path` - the root file path, or array of file paths, used to resolve and load the templates identified when calling
-      [`h.view()`](#hviewtemplate-context-options).
-      Defaults to current working directory.
-    - `partialsPath` - the root file path, or array of file paths, where partials are located. Partials are small segments
-      of template code that can be nested and reused throughout other templates. Defaults to no
-      partials support (empty path).
-    - `helpersPath` - the directory path, or array of directory paths, where helpers are located. Helpers are functions used
-      within templates to perform transformations and other data manipulations using the template
-      context or other inputs. Each valid template file in the helpers directory is loaded and the file name
-      is used as the helper name. The files must export a single method with the signature
-      `function(context)` and return a string. Sub-folders are not supported and are ignored.
-      Defaults to no helpers support (empty path). Note that pug does not support loading helpers
-      this way.
-    - `relativeTo` - a base path used as prefix for `path` and `partialsPath`. No default.
-    - `layout` - if set to `true` or a layout filename, layout support is enabled. A layout is a
-      single template file used as the parent template for other view templates in the same engine.
-      If `true`, the layout template name must be 'layout.ext' where 'ext' is the engine's
-      extension. Otherwise, the provided filename is suffixed with the engine's extension and
-      loaded. Disable `layout` when using Jade as it will handle including any layout files
-      independently. Defaults to `false`.
-    - `layoutPath` - the root file path, or array of file paths, where layout templates are located (using the `relativeTo`
-      prefix if present). Defaults to `path`.
-    - `layoutKeyword` - the key used by the template engine to denote where primary template
-      content should go. Defaults to `'content'`.
-    - `encoding` - the text encoding used by the templates when reading the files and outputting
-      the result. Defaults to `'utf8'`.
-    - `isCached` - if set to `false`, templates will not be cached (thus will be read from file on
-      every use). Defaults to `true`.
-    - `allowAbsolutePaths` - if set to `true`, allows absolute template paths passed to
-      [`h.view()`](#hviewtemplate-context-options).
-      Defaults to `false`.
-    - `allowInsecureAccess` - if set to `true`, allows template paths passed to
-      [`h.view()`](#hviewtemplate-context-options)
-      to contain '../'. Defaults to `false`.
-    - `compileOptions` - options object passed to the engine's compile function. Defaults to empty
-      options `{}`.
-    - `runtimeOptions` - options object passed to the returned function from the compile operation.
-      Defaults to empty options `{}`.
-    - `contentType` - the content type of the engine results. Defaults to `'text/html'`.
-    - `context` - a global context used with all templates. The global context option can be either
-      an object or a function that takes the [`request`](https://github.com/hapijs/hapi/blob/master/API.md#request)
-      as its only argument and returns a context object. The [`request`](https://github.com/hapijs/hapi/blob/master/API.md#request) object is only provided when using
-      the [view handler](#the-view-handler) or [`h.view()`](#hviewtemplate-context-options). When using
-      [`server.render()`](#serverrendertemplate-context-options-callback) or
-      [`request.render()`](#requestrendertemplate-context-options-callback), the [`request`](https://github.com/hapijs/hapi/blob/master/API.md#request) argument will be `null`. When rendering
-      views, the global context will be merged with any context object specified on the handler or using
-      [`h.view()`](#hviewtemplate-context-options). When multiple context objects are used, values from the global
-      context always have lowest precedence.
-
-When [`server.views()`](#serverviewsoptions) is called within a
-plugin, the views manager is only available to [plugins](https://github.com/hapijs/hapi/blob/master/API.md#plugins)
-methods.
-
-`server.views()` returns a [view manager](#view-manager) that can be used to programmatically manipulate the engine configuration.
+- Initializes a plugin's view manager by receiving [`manager options`](#options)
+- Returns the newly created [view manager](#view-manager) for the plugin that called it.
 
 ### `server.render(template, context, [options], [callback])`
 
-Utilizes the server views manager to render a template where:
+Uses the server views manager to render a template where:
 - `template` - the template filename and path, relative to the views manager templates path (`path`
   or `relativeTo`).
 - `context` - optional object used by the template to render context-specific result. Defaults to
@@ -163,7 +199,7 @@ view manager was configured. [`request.render()`](#requestrendertemplate-context
 
 Note that this will not work in `onRequest` extensions added by the plugin because the route isn't yet set at
 this point in the request lifecycle and the [`request.render()`](#requestrendertemplate-context-options-callback) method will produce the same limited results
-[`server.render()`](#serverrendertemplate-context-options-callback) can.
+[`server.render()`](#serverrendertemplate-context-options-callback) can. When using the `onRequest` extension, use the [`h` response toolkit interface](#response-toolkit-interface) instead.
 
 ```js
 const Hapi = require('hapi');
@@ -311,13 +347,3 @@ internals.provision();
     </body>
 </html>
 ```
-
-## View Manager
-
-## `manager.registerHelper(name, helper)`
-
-Registers a helper, on all configured engines that have a `registerHelper()` method, for use during template rendering. Engines without a `registerHelper()` method will be skipped. The `name` is the name that templates should use to reference the helper and `helper` is the function that will be invoked when the helper is called.
-
-## `manager.render(template, context, options, [callback])`
-
-Renders a template. This is typically not needed and it is usually more convenient to use [`server.render()`](#serverrendertemplate-context-options-callback).

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,9 +79,9 @@ internals.assignManager = function (options) {
 internals.render = async function (template, context, options = {}) {
 
     const isServer = (typeof this.route === 'function');
-    const server = (isServer ? this : this.server);
+    const realm = (isServer ? this.realm : this.route.realm);
 
-    const realmState = internals.nearestState(server.realm);
+    const realmState = internals.nearestState(realm);
 
     Hoek.assert(realmState.manager, 'Missing views manager');
     return await realmState.manager.render(template, context, options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const Manager = require('./manager');
 
 const internals = { schema: {} };
 
-internals.schema.manager = Joi.any();
+internals.schema.manager = Manager.schema;
 
 internals.schema.handler = [
     Joi.string(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,9 +11,8 @@ const Manager = require('./manager');
 
 // Declare internals
 
-const internals = { schema: {} };
-
-internals.schema.manager = Manager.schema;
+const internals = {};
+internals.schema = {};
 
 internals.schema.handler = [
     Joi.string(),
@@ -32,8 +31,7 @@ exports.plugin = {
     register: function (server, options) {
 
         if (Object.keys(options).length > 0) {
-            const boundAssignManager = internals.assignManager.bind(server);
-            boundAssignManager(options);
+            internals.assignManager.call(server, options, server.realm.parent);
         }
 
         const rootRealm = internals.getRootRealm(server.realm);
@@ -54,11 +52,9 @@ exports.plugin = {
 };
 
 
-internals.assignManager = function (options) {
+internals.assignManager = function (options, realm) {
 
-    Joi.assert(options, internals.schema.manager, 'Invalid manager options');
-
-    const realm = this.realm.parent || this.realm;
+    realm = realm || this.realm;
     const realmState = internals.state(realm);
 
     Hoek.assert(!realmState.manager, 'Cannot set views manager more than once per realm');
@@ -81,19 +77,30 @@ internals.render = async function (template, context, options = {}) {
     const isServer = (typeof this.route === 'function');
     const realm = (isServer ? this.realm : this.route.realm);
 
-    const realmState = internals.nearestState(realm);
+    const manager = internals.nearestManager(realm);
 
-    Hoek.assert(realmState.manager, 'Missing views manager');
-    return await realmState.manager.render(template, context, options);
+    Hoek.assert(manager, 'Missing views manager');
+    return await manager.render(template, context, options);
 };
-
 
 internals.toolkitView = function (template, context, options) {
 
-    const realmState = internals.nearestState(this.request.route.realm);
+    let realm;
 
-    Hoek.assert(realmState.manager, 'Cannot render view without a views manager configured');
-    return this.response(realmState.manager._response(template, context, options, this.request));
+    // This fingerprint is set when using the 'onRequest' server ext
+    if (this.request.route.fingerprint === '/#') {
+
+        // 'this' is the server that registered the extension
+        realm = this.realm;
+    }
+    else {
+        realm = this.request.route.realm;
+    }
+
+    const manager = internals.nearestManager(realm);
+
+    Hoek.assert(manager, 'Missing views manager');
+    return this.response(manager._response(template, context, options, this.request));
 };
 
 
@@ -140,25 +147,33 @@ internals.state = (realm) => {
 };
 
 
-internals.nearestState = function (realm) {
+internals.nearestManager = function (realm) {
 
-    if (realm.plugins.vision) {
-        return realm.plugins.vision;
+    const pluginState = internals.state(realm);
+    if (pluginState.manager) {
+        return pluginState.manager;
     }
 
-    const parent = realm.parent;
+    let parent = realm.parent;
+    while (parent) {
 
-    return internals.nearestState(parent);
+        const parentManager = internals.state(parent).manager;
+        if (parentManager) {
+            return parentManager;
+        }
+
+        parent = parent.parent;
+    }
+
+    return null;
 };
 
 
 internals.getRootRealm = (realm) => {
 
-    let rootRealm = realm;
-
-    while (rootRealm.parent) {
-        rootRealm = rootRealm.parent;
+    while (realm.parent) {
+        realm = realm.parent;
     }
 
-    return rootRealm;
+    return realm;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -83,21 +83,10 @@ internals.render = async function (template, context, options = {}) {
     return await manager.render(template, context, options);
 };
 
+
 internals.toolkitView = function (template, context, options) {
 
-    let realm;
-
-    // This fingerprint is set when using the 'onRequest' server ext
-    if (this.request.route.fingerprint === '/#') {
-
-        // 'this' is the plugin/server that registered the extension
-        realm = this.realm;
-    }
-    else {
-        realm = this.request.route.realm;
-    }
-
-    const manager = internals.nearestManager(realm);
+    const manager = internals.nearestManager(this.realm);
 
     Hoek.assert(manager, 'Missing views manager');
     return this.response(manager._response(template, context, options, this.request));

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,9 +157,9 @@ internals.nearestManager = function (realm) {
     let parent = realm.parent;
     while (parent) {
 
-        const parentManager = internals.state(parent).manager;
-        if (parentManager) {
-            return parentManager;
+        const parentState = internals.state(parent);
+        if (parentState.manager) {
+            return parentState.manager;
         }
 
         parent = parent.parent;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const Manager = require('./manager');
 
 const internals = { schema: {} };
 
-internals.schema.manager = Manager.schema;
+internals.schema.manager = Joi.any();
 
 internals.schema.handler = [
     Joi.string(),
@@ -31,11 +31,7 @@ exports.plugin = {
 
     register: function (server, options) {
 
-        if (Joi.validate(options, Joi.object()) &&
-            Object.keys(options).length > 0) {
-
-            Joi.assert(options, internals.schema.manager, 'Bad plugin options passed to vision.');
-
+        if (Object.keys(options).length > 0) {
             const boundAssignManager = internals.assignManager.bind(server);
             boundAssignManager(options);
         }
@@ -58,7 +54,7 @@ exports.plugin = {
 };
 
 
-internals.assignManager = function(options) {
+internals.assignManager = function (options) {
 
     Joi.assert(options, internals.schema.manager, 'Invalid manager options');
 
@@ -115,7 +111,7 @@ internals.handler = function (route, options) {
         options: options.options
     };
 
-    return function (request, responder) {
+    return function (request, h) {
 
         const context = {
             params: request.params,
@@ -132,7 +128,7 @@ internals.handler = function (route, options) {
             }
         }
 
-        return responder.view(settings.template, context, settings.options);
+        return h.view(settings.template, context, settings.options);
     };
 };
 
@@ -150,16 +146,9 @@ internals.nearestState = function (realm) {
         return realm.plugins.vision;
     }
 
-    let parent = realm.parent;
-    while (parent) {
-        if (parent.plugins.vision) {
-            return parent.plugins.vision;
-        }
+    const parent = realm.parent;
 
-        parent = parent.parent;
-    }
-
-    return {};
+    return internals.nearestState(parent);
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ internals.toolkitView = function (template, context, options) {
     // This fingerprint is set when using the 'onRequest' server ext
     if (this.request.route.fingerprint === '/#') {
 
-        // 'this' is the server that registered the extension
+        // 'this' is the plugin/server that registered the extension
         realm = this.realm;
     }
     else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,54 +11,72 @@ const Manager = require('./manager');
 
 // Declare internals
 
-const internals = {};
+const internals = { schema: {} };
 
+internals.schema.manager = Manager.schema;
 
-internals.schema = Joi.alternatives([
+internals.schema.handler = [
     Joi.string(),
     Joi.object({
         template: Joi.string(),
         context: Joi.object(),
         options: Joi.object()
     })
-]);
-
+];
 
 exports.plugin = {
-    once: true,
+
+    multiple: true,
     pkg: require('../package.json'),
 
-    register: function (server, pluginOptions) {
+    register: function (server, options) {
 
-        server.decorate('server', 'views', function (options) {
+        if (Joi.validate(options, Joi.object()) &&
+            Object.keys(options).length > 0) {
 
-            Hoek.assert(options, 'Missing views options');
-            this.realm.plugins.vision = this.realm.plugins.vision || {};
-            Hoek.assert(!this.realm.plugins.vision.manager, 'Cannot set views manager more than once');
+            Joi.assert(options, internals.schema.manager, 'Bad plugin options passed to vision.');
 
-            if (!options.relativeTo &&
-                this.realm.settings.files.relativeTo) {
+            const boundAssignManager = internals.assignManager.bind(server);
+            boundAssignManager(options);
+        }
 
-                options = Hoek.shallow(options);
-                options.relativeTo = this.realm.settings.files.relativeTo;
-            }
+        const rootRealm = internals.getRootRealm(server.realm);
+        const rootState = internals.state(rootRealm);
 
-            const manager = new Manager(options);
-            this.realm.plugins.vision.manager = manager;
-            return manager;
-        });
+        if (rootState.setup) {
+            return;
+        }
 
+        server.decorate('server', 'views', internals.assignManager);
         server.decorate('server', 'render', internals.render);
         server.decorate('request', 'render', internals.render);
         server.decorate('handler', 'view', internals.handler);
+        server.decorate('toolkit', 'view', internals.toolkitView);
 
-        server.decorate('toolkit', 'view', function (template, context, options) {
-
-            const realm = (this.realm.plugins.vision || this.request.server.realm.plugins.vision || {});
-            Hoek.assert(realm.manager, 'Cannot render view without a views manager configured');
-            return this.response(realm.manager._response(template, context, options, this.request));
-        });
+        rootState.setup = true;
     }
+};
+
+
+internals.assignManager = function(options) {
+
+    Joi.assert(options, internals.schema.manager, 'Invalid manager options');
+
+    const realm = this.realm.parent || this.realm;
+    const realmState = internals.state(realm);
+
+    Hoek.assert(!realmState.manager, 'Cannot set views manager more than once per realm');
+
+    if (!options.relativeTo &&
+        realm.settings.files.relativeTo) {
+
+        options = Hoek.shallow(options);
+        options.relativeTo = realm.settings.files.relativeTo;
+    }
+
+    const manager = new Manager(options);
+    realmState.manager = manager;
+    return manager;
 };
 
 
@@ -66,34 +84,26 @@ internals.render = async function (template, context, options = {}) {
 
     const isServer = (typeof this.route === 'function');
     const server = (isServer ? this : this.server);
-    const vision = ((!isServer ? this.route.realm.plugins.vision : null) || internals.realm(server));
-    Hoek.assert(vision.manager, 'Missing views manager');
-    return await vision.manager.render(template, context, options);
+
+    const realmState = internals.nearestState(server.realm);
+
+    Hoek.assert(realmState.manager, 'Missing views manager');
+    return await realmState.manager.render(template, context, options);
 };
 
 
-internals.realm = function (server) {
+internals.toolkitView = function (template, context, options) {
 
-    if (server.realm.plugins.vision) {
-        return server.realm.plugins.vision;
-    }
+    const realmState = internals.nearestState(this.request.route.realm);
 
-    let parent = server.realm.parent;
-    while (parent) {
-        if (parent.plugins.vision) {
-            return parent.plugins.vision;
-        }
-
-        parent = parent.parent;
-    }
-
-    return {};
+    Hoek.assert(realmState.manager, 'Cannot render view without a views manager configured');
+    return this.response(realmState.manager._response(template, context, options, this.request));
 };
 
 
 internals.handler = function (route, options) {
 
-    Joi.assert(options, internals.schema, 'Invalid view handler options (' + route.path + ')');
+    Joi.assert(options, internals.schema.handler, 'Invalid view handler options (' + route.path + ')');
 
     if (typeof options === 'string') {
         options = { template: options };
@@ -124,4 +134,42 @@ internals.handler = function (route, options) {
 
         return responder.view(settings.template, context, settings.options);
     };
+};
+
+
+internals.state = (realm) => {
+
+    const state = realm.plugins.vision = realm.plugins.vision || {};
+    return state;
+};
+
+
+internals.nearestState = function (realm) {
+
+    if (realm.plugins.vision) {
+        return realm.plugins.vision;
+    }
+
+    let parent = realm.parent;
+    while (parent) {
+        if (parent.plugins.vision) {
+            return parent.plugins.vision;
+        }
+
+        parent = parent.parent;
+    }
+
+    return {};
+};
+
+
+internals.getRootRealm = (realm) => {
+
+    let rootRealm = realm;
+
+    while (rootRealm.parent) {
+        rootRealm = rootRealm.parent;
+    }
+
+    return rootRealm;
 };

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -170,6 +170,9 @@ exports = module.exports = internals.Manager = function (options) {
     });
 };
 
+// Set public schema on Manager
+
+exports.schema = internals.schema.manager
 
 internals.Manager.prototype._loadPartials = function (engine) {
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -170,10 +170,6 @@ exports = module.exports = internals.Manager = function (options) {
     });
 };
 
-// Set public schema on Manager
-
-exports.schema = internals.schema.manager;
-
 internals.Manager.prototype._loadPartials = function (engine) {
 
     if (!engine.config.partialsPath ||

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -172,7 +172,7 @@ exports = module.exports = internals.Manager = function (options) {
 
 // Set public schema on Manager
 
-exports.schema = internals.schema.manager
+exports.schema = internals.schema.manager;
 
 internals.Manager.prototype._loadPartials = function (engine) {
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -170,6 +170,7 @@ exports = module.exports = internals.Manager = function (options) {
     });
 };
 
+
 internals.Manager.prototype._loadPartials = function (engine) {
 
     if (!engine.config.partialsPath ||

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "scripts": {
         "test": "lab -a code -t 100 -L",
         "test-cov-html": "lab -a code -r html -o coverage.html",
-        "coveralls": "lab -r lcov | coveralls",
         "lint": "lab -L -d"
     },
     "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -782,11 +782,13 @@ describe('Plugin', () => {
         const resPlugin1 = await server.inject('/viewPluginOne');
         const resPlugin2 = await server.inject('/viewPluginTwo');
         const resPlugin3 = await server.inject('/viewPluginThree');
+        const resPlugin4 = await server.inject('/viewPluginFour');
         const resRootServer = await server.inject('/viewRootServer');
 
         expect(resPlugin1.result).to.equal('<h1>Plugin One</h1>');
         expect(resPlugin2.result).to.equal('<h1>Plugin Two</h1>');
         expect(resPlugin3.result).to.equal('<div>\n    <h1>Plugin Three</h1>\n</div>\n');
+        expect(resPlugin4.result).to.equal('<h1>Plugin Four</h1>');
         expect(resRootServer.result).to.equal('<div>\n    <h1>Root Server</h1>\n</div>\n');
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -690,7 +690,7 @@ describe('Plugin', () => {
                     method: 'GET',
                     handler: (request, h) => {
 
-                        return h.view('test', { message: 'Plugin One' });
+                        return request.render('test', { message: 'Plugin One' });
                     }
                 });
             }
@@ -717,6 +717,15 @@ describe('Plugin', () => {
             name: 'three',
             register: async (server, options) => {
 
+                await server.register({
+                    plugin: Vision,
+                    options: {
+                        engines: { 'html': Handlebars },
+                        relativeTo: Path.join(__dirname, '/templates'),
+                        path: 'plugin'
+                    }
+                });
+
                 await server.register(two);
 
                 return server.route({
@@ -724,7 +733,7 @@ describe('Plugin', () => {
                     method: 'GET',
                     handler: (request, h) => {
 
-                        return request.render('test', { message: 'Plugin Three' });
+                        return server.render('test', { message: 'Plugin Three' });
                     }
                 });
             }
@@ -735,15 +744,6 @@ describe('Plugin', () => {
             register: async (server, options) => {
 
                 await server.register(three);
-
-                server.register({
-                    plugin: Vision,
-                    options: {
-                        engines: { 'html': Handlebars },
-                        relativeTo: Path.join(__dirname, '/templates'),
-                        path: 'plugin'
-                    }
-                });
 
                 return server.route({
                     path: '/viewPluginFour',
@@ -787,8 +787,8 @@ describe('Plugin', () => {
 
         expect(resPlugin1.result).to.equal('<h1>Plugin One</h1>');
         expect(resPlugin2.result).to.equal('<h1>Plugin Two</h1>');
-        expect(resPlugin3.result).to.equal('<div>\n    <h1>Plugin Three</h1>\n</div>\n');
-        expect(resPlugin4.result).to.equal('<h1>Plugin Four</h1>');
+        expect(resPlugin3.result).to.equal('<h1>Plugin Three</h1>');
+        expect(resPlugin4.result).to.equal('<div>\n    <h1>Plugin Four</h1>\n</div>\n');
         expect(resRootServer.result).to.equal('<div>\n    <h1>Root Server</h1>\n</div>\n');
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -443,7 +443,7 @@ describe('views()', () => {
 
                 const views = {
                     engines: { 'html': Handlebars },
-                    path: __dirname + '/templates/plugin'
+                    path: './templates/plugin'
                 };
 
                 await server.register(Vision);
@@ -501,7 +501,7 @@ describe('views()', () => {
 
                 const views = {
                     engines: { 'html': Handlebars },
-                    path: __dirname + '/templates/plugin'
+                    path: './templates/plugin'
                 };
 
                 await server.register(Vision);

--- a/test/index.js
+++ b/test/index.js
@@ -629,7 +629,7 @@ describe('Plugin', () => {
                     }
                 });
 
-                return server.route({
+                server.route({
                     path: '/viewPluginOne',
                     method: 'GET',
                     handler: (request, h) => {
@@ -653,7 +653,7 @@ describe('Plugin', () => {
                     }
                 });
 
-                return server.route({
+                server.route({
                     path: '/viewPluginTwo',
                     method: 'GET',
                     handler: (request, h) => {
@@ -719,7 +719,7 @@ describe('Plugin', () => {
             name: 'one',
             register: function (server, options) {
 
-                return server.route({
+                server.route({
                     path: '/viewPluginOne',
                     method: 'GET',
                     handler: (request, h) => {
@@ -745,7 +745,7 @@ describe('Plugin', () => {
 
                 await server.register(one);
 
-                return server.route({
+                server.route({
                     path: '/viewPluginTwo',
                     method: 'GET',
                     handler: (request, h) => {
@@ -780,7 +780,7 @@ describe('Plugin', () => {
                     return h.continue;
                 });
 
-                return server.route({
+                server.route({
                     path: '/viewPluginThree',
                     method: 'GET',
                     handler: (request, h) => {
@@ -797,7 +797,7 @@ describe('Plugin', () => {
 
                 await server.register(three);
 
-                return server.route({
+                server.route({
                     path: '/viewPluginFour',
                     method: 'GET',
                     handler: {

--- a/test/manager.js
+++ b/test/manager.js
@@ -33,7 +33,9 @@ describe('Manager', () => {
     it('renders handlebars template', async () => {
 
         const server = Hapi.server();
-        await await server.register(Vision);
+
+        await server.register(Vision);
+
         server.views({
             engines: {
                 html: {
@@ -71,7 +73,7 @@ describe('Manager', () => {
     it('sets content type', async () => {
 
         const server = Hapi.server();
-        await await server.register(Vision);
+        await server.register(Vision);
         server.views({
             engines: {
                 html: {
@@ -92,7 +94,7 @@ describe('Manager', () => {
     it('errors on invalid template path', async () => {
 
         const server = Hapi.server({ debug: false });
-        await await server.register(Vision);
+        await server.register(Vision);
         server.views({
             engines: { 'html': require('handlebars') },
             path: __dirname + '/templates/invalid'

--- a/test/manager.js
+++ b/test/manager.js
@@ -401,6 +401,36 @@ describe('Manager', () => {
             await expect(manager.render('valid/test')).to.reject('Initialization error');
         });
 
+
+        it('throws on invalid options', () => {
+
+            expect(() => {
+
+                new Manager({
+                    path: __dirname + '/templates',
+                    engines: {
+                        html: {
+                            compile: function (string, options1) {
+
+                                return function (context, options2) {
+
+                                    return string;
+                                };
+                            },
+
+                            prepare: function (options, next) {
+
+                                throw new Error('Initialization error');
+                            }
+                        }
+                    },
+                    badValue: 'badValue'
+                });
+            })
+                .to.throw(/"badValue" is not allowed/);
+        });
+
+
         it('only initializes once before rendering', async () => {
 
             let initialized = 0;

--- a/test/templates/plugin2/test.html
+++ b/test/templates/plugin2/test.html
@@ -1,0 +1,1 @@
+<h1>{{plugin2Message}}</h1>

--- a/test/templates/plugin3/test.html
+++ b/test/templates/plugin3/test.html
@@ -1,0 +1,1 @@
+<h1>{{plugin3Message}}</h1>


### PR DESCRIPTION
- Feedback welcome

- Set multiple: true, as it's required to pass plugin options
- Register vision via `server.register({ plugin: Vision, options: { ... });` where:
    - options is a manager config, is synonymous with `server.views`
- Effectively, the only thing this adds is the ability to use

        await server.register({
            plugin: Vision,
            options: {/* view manager options */}
        });

        // which will have the same effect as

        await server.register(Vision);
        server.views({/* view manager options */});