### PR TITLE
Handle ESM for helpers

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -256,10 +256,11 @@ internals.Manager.prototype._loadHelpers = function (engine) {
                     delete require.cache[require.resolve(file)]; // bust require's cache
                 }
 
-                const helper = require(file);
+                const required = require(file);
+                const offset = path.slice(-1) === Path.sep ? 0 : 1;
+                const name = file.slice(path.length + offset, -Path.extname(file).length);
+                const helper = required[name] || required.default || required;
                 if (typeof helper === 'function') {
-                    const offset = path.slice(-1) === Path.sep ? 0 : 1;
-                    const name = file.slice(path.length + offset, -Path.extname(file).length);
                     engine.module.registerHelper(name, helper);
                 }
             }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "node": ">=8.9.0"
     },
     "scripts": {
-        "test": "lab -a code -t 100 -L",
+        "test": "lab -a code -t 100 -L -I '__core-js_shared__'",
         "test-cov-html": "lab -a code -r html -o coverage.html",
         "lint": "lab -L -d"
     },

--- a/test/manager.js
+++ b/test/manager.js
@@ -1415,6 +1415,30 @@ describe('Manager', () => {
             expect(rendered).to.equal('Nav:{{> nav}}|{{> nested/nav}}');
         });
 
+        it('loads ESM default export helpers and render them', async () => {
+
+            const tempView = new Manager({
+                engines: { html: { module: Handlebars.create() } },    // Clear environment from other tests
+                path: __dirname + '/templates/valid',
+                helpersPath: __dirname + '/templates/valid/helpers'
+            });
+
+            const rendered = await tempView.render('testHelpersESMDefault', { something: 'uppercase' });
+            expect(rendered).to.equal('<p>This is all UPPERCASE and this is how we like it!</p>\n');
+        });
+
+        it('loads ESM named export helpers and render them', async () => {
+
+            const tempView = new Manager({
+                engines: { html: { module: Handlebars.create() } },    // Clear environment from other tests
+                path: __dirname + '/templates/valid',
+                helpersPath: __dirname + '/templates/valid/helpers'
+            });
+
+            const rendered = await tempView.render('testHelpersESMNamedExport', { something: 'uppercase' });
+            expect(rendered).to.equal('<p>This is all UPPERCASE and this is how we like it!</p>\n');
+        });
+
         it('loads helpers and render them', async () => {
 
             const tempView = new Manager({

--- a/test/templates/valid/helpers/uppercaseESMDefault.js
+++ b/test/templates/valid/helpers/uppercaseESMDefault.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports.default = function uppercaseESMDefault(context) {
+
+    return context.toUpperCase();
+};

--- a/test/templates/valid/helpers/uppercaseESMNamedExport.js
+++ b/test/templates/valid/helpers/uppercaseESMNamedExport.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports.uppercaseESMNamedExport = function uppercaseESMNamedExport(context) {
+
+    return context.toUpperCase();
+};

--- a/test/templates/valid/testHelpersESMDefault.html
+++ b/test/templates/valid/testHelpersESMDefault.html
@@ -1,0 +1,1 @@
+<p>This is all {{uppercaseESMDefault this.something}} and this is {{long "how"}} we like it!</p>

--- a/test/templates/valid/testHelpersESMNamedExport.html
+++ b/test/templates/valid/testHelpersESMNamedExport.html
@@ -1,0 +1,1 @@
+<p>This is all {{uppercaseESMNamedExport this.something}} and this is {{long "how"}} we like it!</p>


### PR DESCRIPTION
named export first, then default, then CJS

should resolve #145 