### PR TITLE
Move Joi schemas to schemas file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,8 @@
 
 const Hoek = require('hoek');
 const Joi = require('joi');
+const Schemas = require('./schemas');
+
 // Additional helper modules required in constructor
 
 const Manager = require('./manager');
@@ -12,16 +14,6 @@ const Manager = require('./manager');
 // Declare internals
 
 const internals = {};
-internals.schema = {};
-
-internals.schema.handler = [
-    Joi.string(),
-    Joi.object({
-        template: Joi.string(),
-        context: Joi.object(),
-        options: Joi.object()
-    })
-];
 
 exports.plugin = {
 
@@ -100,7 +92,7 @@ internals.toolkitView = function (template, context, options) {
 
 internals.handler = function (route, options) {
 
-    Joi.assert(options, internals.schema.handler, 'Invalid view handler options (' + route.path + ')');
+    Joi.assert(options, Schemas.handler, 'Invalid view handler options (' + route.path + ')');
 
     if (typeof options === 'string') {
         options = { template: options };

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -8,6 +8,7 @@ const Boom = require('boom');
 const Hoek = require('hoek');
 const Joi = require('joi');
 const Items = require('items');
+const Schemas = require('./schemas');
 
 // Additional helper modules required in constructor
 
@@ -32,52 +33,9 @@ internals.defaults = {
     context: null
 };
 
-
-internals.schema = {};
-
-
-internals.schema.viewOverride = Joi.object({
-    path: [Joi.array().items(Joi.string()), Joi.string()],
-    relativeTo: Joi.string(),
-    compileOptions: Joi.object(),
-    runtimeOptions: Joi.object(),
-    layout: Joi.string().allow(false, true),
-    layoutKeyword: Joi.string(),
-    layoutPath: [Joi.array().items(Joi.string()), Joi.string()],
-    encoding: Joi.string(),
-    allowAbsolutePaths: Joi.boolean(),
-    allowInsecureAccess: Joi.boolean(),
-    contentType: Joi.string()
-});
-
-
-internals.schema.viewBase = internals.schema.viewOverride.keys({
-    partialsPath: [Joi.array().items(Joi.string()), Joi.string()],
-    helpersPath: [Joi.array().items(Joi.string()), Joi.string()],
-    isCached: Joi.boolean(),
-    compileMode: Joi.string().valid('sync', 'async'),
-    defaultExtension: Joi.string()
-});
-
-
-internals.schema.manager = internals.schema.viewBase.keys({
-    engines: Joi.object().required(),
-    context: [Joi.object(), Joi.func()]
-});
-
-
-internals.schema.view = internals.schema.viewBase.keys({
-    module: Joi.object({
-        compile: Joi.func().required()
-    })
-        .options({ allowUnknown: true })
-        .required()
-});
-
-
 exports = module.exports = internals.Manager = function (options) {
 
-    Joi.assert(options, internals.schema.manager);
+    Joi.assert(options, Schemas.manager);
 
     // Save non-defaults values
 
@@ -113,7 +71,7 @@ exports = module.exports = internals.Manager = function (options) {
             engine.config = defaults;
         }
         else {
-            Joi.assert(config, internals.schema.view);
+            Joi.assert(config, Schemas.view);
 
             engine.module = config.module;
             engine.config = Hoek.applyToDefaultsWithShallow(defaults, config, ['module']);
@@ -572,7 +530,7 @@ internals.Manager.prototype._compile = function (template, engine, settings, cal
 
 internals.Manager.prototype._response = function (template, context, options, request) {
 
-    Joi.assert(options, internals.schema.viewOverride);
+    Joi.assert(options, Schemas.viewOverride);
 
     const source = { manager: this, template, context, options };
     return request.generateResponse(source, { variety: 'view', marshal: internals.marshal, prepare: internals.prepare });

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const Joi = require('joi');
+
+// root schemas
+
+exports.handler = [
+    Joi.string(),
+    Joi.object({
+        template: Joi.string(),
+        context: Joi.object(),
+        options: Joi.object()
+    })
+];
+
+
+// Manager schemas
+
+exports.viewOverride = Joi.object({
+    path: [Joi.array().items(Joi.string()), Joi.string()],
+    relativeTo: Joi.string(),
+    compileOptions: Joi.object(),
+    runtimeOptions: Joi.object(),
+    layout: Joi.string().allow(false, true),
+    layoutKeyword: Joi.string(),
+    layoutPath: [Joi.array().items(Joi.string()), Joi.string()],
+    encoding: Joi.string(),
+    allowAbsolutePaths: Joi.boolean(),
+    allowInsecureAccess: Joi.boolean(),
+    contentType: Joi.string()
+});
+
+
+exports.viewBase = exports.viewOverride.keys({
+    partialsPath: [Joi.array().items(Joi.string()), Joi.string()],
+    helpersPath: [Joi.array().items(Joi.string()), Joi.string()],
+    isCached: Joi.boolean(),
+    compileMode: Joi.string().valid('sync', 'async'),
+    defaultExtension: Joi.string()
+});
+
+
+exports.manager = exports.viewBase.keys({
+    engines: Joi.object().required(),
+    context: [Joi.object(), Joi.func()]
+});
+
+
+exports.view = exports.viewBase.keys({
+    module: Joi.object({
+        compile: Joi.func().required()
+    })
+        .options({ allowUnknown: true })
+        .required()
+});


### PR DESCRIPTION
I figure I'll use this PR to open discussion or thinking around sharing Joi schemas and keeping them more centralized.

A couple times in projects I've enjoyed the thought of being able to use part of a Joi schema for both route payload validation and [schwifty](https://github.com/hapipal/schwifty) model schemas.

The `schemas / index.js` and friends, or `schemas.js` pattern is interesting to me, and I think makes a better use of Joi's existing extensibility via `.keys(` and other methods