### PR TITLE
Convert manager to a class

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -55,6 +55,8 @@ module.exports = class Manager {
         const extensions = Object.keys(engines);
         Hoek.assert(extensions.length, 'Views manager requires at least one registered extension handler');
 
+        // Private class props
+
         this._context = defaults.context;
         this._engines = {};
         this._defaultExtension = defaultExtension || (extensions.length === 1 ? extensions[0] : '');

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -33,452 +33,498 @@ internals.defaults = {
     context: null
 };
 
-exports = module.exports = internals.Manager = function (options) {
+module.exports = class Manager {
 
-    Joi.assert(options, Schemas.manager);
+    constructor(options) {
 
-    // Save non-defaults values
+        Joi.assert(options, Schemas.manager);
 
-    const engines = options.engines;
-    const defaultExtension = options.defaultExtension;
+        // Save non-defaults values
 
-    // Clone options
+        const engines = options.engines;
+        const defaultExtension = options.defaultExtension;
 
-    const defaults = Hoek.applyToDefaultsWithShallow(internals.defaults, options, ['engines', 'context']);
-    delete defaults.engines;
-    delete defaults.defaultExtension;
+        // Clone options
 
-    // Prepare manager state
+        const defaults = Hoek.applyToDefaultsWithShallow(internals.defaults, options, ['engines', 'context']);
+        delete defaults.engines;
+        delete defaults.defaultExtension;
 
-    const extensions = Object.keys(engines);
-    Hoek.assert(extensions.length, 'Views manager requires at least one registered extension handler');
+        // Prepare manager state
 
-    this._context = defaults.context;
-    this._engines = {};
-    this._defaultExtension = defaultExtension || (extensions.length === 1 ? extensions[0] : '');
+        const extensions = Object.keys(engines);
+        Hoek.assert(extensions.length, 'Views manager requires at least one registered extension handler');
 
-    // Load engines
+        this._context = defaults.context;
+        this._engines = {};
+        this._defaultExtension = defaultExtension || (extensions.length === 1 ? extensions[0] : '');
 
-    extensions.forEach((extension) => {
+        // Load engines
 
-        const config = engines[extension];
-        const engine = {};
+        extensions.forEach((extension) => {
 
-        if (config.compile &&
-            typeof config.compile === 'function') {
+            const config = engines[extension];
+            const engine = {};
 
-            engine.module = config;
-            engine.config = defaults;
-        }
-        else {
-            Joi.assert(config, Schemas.view);
+            if (config.compile &&
+                typeof config.compile === 'function') {
 
-            engine.module = config.module;
-            engine.config = Hoek.applyToDefaultsWithShallow(defaults, config, ['module']);
-        }
+                engine.module = config;
+                engine.config = defaults;
+            }
+            else {
+                Joi.assert(config, Schemas.view);
 
-        engine.suffix = '.' + extension;
-        engine.compileFunc = engine.module.compile;
+                engine.module = config.module;
+                engine.config = Hoek.applyToDefaultsWithShallow(defaults, config, ['module']);
+            }
 
-        if (engine.config.compileMode === 'sync') {
-            engine.compileFunc = function (str, opt, next) {
+            engine.suffix = '.' + extension;
+            engine.compileFunc = engine.module.compile;
 
-                let compiled = null;
-                try {
-                    compiled = engine.module.compile(str, opt);
-                }
-                catch (err) {
-                    return next(err);
-                }
+            if (engine.config.compileMode === 'sync') {
+                engine.compileFunc = function (str, opt, next) {
 
-                const renderer = function (context, runtimeOptions, renderNext) {
-
-                    let rendered = null;
+                    let compiled = null;
                     try {
-                        rendered = compiled(context, runtimeOptions);
+                        compiled = engine.module.compile(str, opt);
                     }
                     catch (err) {
-                        return renderNext(err);
+                        return next(err);
                     }
 
-                    return renderNext(null, rendered);
+                    const renderer = function (context, runtimeOptions, renderNext) {
+
+                        let rendered = null;
+                        try {
+                            rendered = compiled(context, runtimeOptions);
+                        }
+                        catch (err) {
+                            return renderNext(err);
+                        }
+
+                        return renderNext(null, rendered);
+                    };
+
+                    return next(null, renderer);
                 };
-
-                return next(null, renderer);
-            };
-        }
-
-        if (engine.config.isCached) {
-            engine.cache = {};
-        }
-
-        // When a prepare function is provided, state needs to be initialized before trying to compile and render
-        engine.ready = !(engine.module.prepare && typeof engine.module.prepare === 'function');
-
-        // Load partials and helpers
-
-        this._loadPartials(engine);
-        this._loadHelpers(engine);
-
-        // Set engine
-
-        this._engines[extension] = engine;
-    });
-};
-
-
-internals.Manager.prototype._loadPartials = function (engine) {
-
-    if (!engine.config.partialsPath ||
-        !engine.module.registerPartial ||
-        typeof engine.module.registerPartial !== 'function') {
-
-        return;
-    }
-
-    const load = function () {
-
-        const partialsPaths = [].concat(engine.config.partialsPath);
-
-        partialsPaths.forEach((partialsPath) => {
-
-            const path = internals.path(engine.config.relativeTo, partialsPath);
-            const files = traverse(path);
-            files.forEach((file) => {
-
-                const offset = path.slice(-1) === Path.sep ? 0 : 1;
-                const name = file.slice(path.length + offset, -engine.suffix.length).replace(/\\/g, '/');
-                const src = Fs.readFileSync(file).toString(engine.config.encoding);
-                engine.module.registerPartial(name, src);
-            });
-        });
-    };
-
-    const traverse = function (path) {
-
-        let files = [];
-
-        Fs.readdirSync(path).forEach((file) => {
-
-            file = Path.join(path, file);
-            const stat = Fs.statSync(file);
-            if (stat.isDirectory()) {
-                files = files.concat(traverse(file));
-                return;
             }
 
-            if (Path.basename(file)[0] !== '.' &&
-                Path.extname(file) === engine.suffix) {
-
-                files.push(file);
-            }
-        });
-
-        return files;
-    };
-
-    load();
-};
-
-
-internals.Manager.prototype._loadHelpers = function (engine) {
-
-    if (!engine.config.helpersPath ||
-        !engine.module.registerHelper ||
-        typeof engine.module.registerHelper !== 'function') {
-
-        return;
-    }
-
-    const helpersPaths = [].concat(engine.config.helpersPath);
-
-    helpersPaths.forEach((helpersPath) => {
-
-        let path = internals.path(engine.config.relativeTo, helpersPath);
-        if (!Path.isAbsolute(path)) {
-            path = Path.join(process.cwd(), path);
-        }
-
-        Fs.readdirSync(path).forEach((file) => {
-
-            file = Path.join(path, file);
-            const stat = Fs.statSync(file);
-            if (stat.isDirectory() ||
-                Path.basename(file).startsWith('.') ||
-                !Object.keys(require.extensions).includes(Path.extname(file))) {
-                return;
+            if (engine.config.isCached) {
+                engine.cache = {};
             }
 
-            try {
-                if (!engine.config.isCached) {
-                    delete require.cache[require.resolve(file)]; // bust require's cache
-                }
+            // When a prepare function is provided, state needs to be initialized before trying to compile and render
+            engine.ready = !(engine.module.prepare && typeof engine.module.prepare === 'function');
 
-                const required = require(file);
-                const offset = path.slice(-1) === Path.sep ? 0 : 1;
-                const name = file.slice(path.length + offset, -Path.extname(file).length);
-                const helper = required[name] || required.default || required;
-                if (typeof helper === 'function') {
-                    engine.module.registerHelper(name, helper);
-                }
-            }
-            catch (err) {
-                console.warn('WARNING: vision failed to load helper \'%s\': %s', file, err.message);
-            }
-        });
-    });
-};
+            // Load partials and helpers
 
-
-internals.Manager.prototype.registerHelper = function (name, helper) {
-
-    Object.keys(this._engines).forEach((extension) => {
-
-        const engine = this._engines[extension];
-
-        if (typeof engine.module.registerHelper === 'function') {
-            engine.module.registerHelper(name, helper);
-        }
-    });
-};
-
-
-internals.Manager.prototype.render = function (filename, context, options, request) {
-
-    return new Promise((resolve, reject) => {
-
-        this._prepare(filename, options, (err, compiled) => {
-
-            if (err) {
-                return reject(err);
-            }
-
-            this._render(compiled, context, request, (err, rendered) => {
-
-                if (err) {
-                    return reject(err);
-                }
-
-                return resolve(rendered);
-            });
-        });
-    });
-};
-
-
-internals.Manager.prototype._prepare = function (template, options, callback) {
-
-    options = options || {};
-
-    const fileExtension = Path.extname(template).slice(1);
-    const extension = fileExtension || this._defaultExtension;
-    if (!extension) {
-        return callback(Boom.badImplementation('Unknown extension and no defaultExtension configured for view template: ' + template));
-    }
-
-    const engine = this._engines[extension];
-    if (!engine) {
-        return callback(Boom.badImplementation('No view engine found for file: ' + template));
-    }
-
-    template = template + (fileExtension ? '' : engine.suffix);
-
-    // Engine is ready to render
-
-    if (engine.ready) {
-        return this._prepareTemplates(template, engine, options, callback);
-    }
-
-    // Engine needs initialization
-
-    return this._prepareEngine(engine, (err) => {
-
-        if (err) {
-            return callback(err);
-        }
-
-        return this._prepareTemplates(template, engine, options, callback);
-    });
-};
-
-
-internals.Manager.prototype._prepareEngine = function (engine, next) {
-
-    // _prepareEngine can only be invoked when the prepare function is defined
-
-    try {
-        return engine.module.prepare(engine.config, (err) => {
-
-            if (err) {
-                return next(err);
-            }
-
-            engine.ready = true;
-            return next();
-        });
-    }
-    catch (err) {
-        return next(err);
-    }
-};
-
-
-internals.Manager.prototype._prepareTemplates = function (template, engine, options, callback) {
-
-    const compiled = {
-        settings: Hoek.applyToDefaults(engine.config, options)
-    };
-
-    this._path(template, compiled.settings, false, (err, templatePath) => {
-
-        if (err) {
-            return callback(err);
-        }
-
-        if (!engine.config.isCached) {
             this._loadPartials(engine);
             this._loadHelpers(engine);
+
+            // Set engine
+
+            this._engines[extension] = engine;
+        });
+    }
+
+
+    _loadPartials(engine) {
+
+        if (!engine.config.partialsPath ||
+            !engine.module.registerPartial ||
+            typeof engine.module.registerPartial !== 'function') {
+
+            return;
         }
 
-        this._compile(templatePath, engine, compiled.settings, (err, compiledTemplate) => {
+        const load = function () {
+
+            const partialsPaths = [].concat(engine.config.partialsPath);
+
+            partialsPaths.forEach((partialsPath) => {
+
+                const path = internals.path(engine.config.relativeTo, partialsPath);
+                const files = traverse(path);
+                files.forEach((file) => {
+
+                    const offset = path.slice(-1) === Path.sep ? 0 : 1;
+                    const name = file.slice(path.length + offset, -engine.suffix.length).replace(/\\/g, '/');
+                    const src = Fs.readFileSync(file).toString(engine.config.encoding);
+                    engine.module.registerPartial(name, src);
+                });
+            });
+        };
+
+        const traverse = function (path) {
+
+            let files = [];
+
+            Fs.readdirSync(path).forEach((file) => {
+
+                file = Path.join(path, file);
+                const stat = Fs.statSync(file);
+                if (stat.isDirectory()) {
+                    files = files.concat(traverse(file));
+                    return;
+                }
+
+                if (Path.basename(file)[0] !== '.' &&
+                    Path.extname(file) === engine.suffix) {
+
+                    files.push(file);
+                }
+            });
+
+            return files;
+        };
+
+        load();
+    }
+
+
+    _loadHelpers(engine) {
+
+        if (!engine.config.helpersPath ||
+            !engine.module.registerHelper ||
+            typeof engine.module.registerHelper !== 'function') {
+
+            return;
+        }
+
+        const helpersPaths = [].concat(engine.config.helpersPath);
+
+        helpersPaths.forEach((helpersPath) => {
+
+            let path = internals.path(engine.config.relativeTo, helpersPath);
+            if (!Path.isAbsolute(path)) {
+                path = Path.join(process.cwd(), path);
+            }
+
+            Fs.readdirSync(path).forEach((file) => {
+
+                file = Path.join(path, file);
+                const stat = Fs.statSync(file);
+                if (stat.isDirectory() ||
+                    Path.basename(file).startsWith('.') ||
+                    !Object.keys(require.extensions).includes(Path.extname(file))) {
+                    return;
+                }
+
+                try {
+                    if (!engine.config.isCached) {
+                        delete require.cache[require.resolve(file)]; // bust require's cache
+                    }
+
+                    const required = require(file);
+                    const offset = path.slice(-1) === Path.sep ? 0 : 1;
+                    const name = file.slice(path.length + offset, -Path.extname(file).length);
+                    const helper = required[name] || required.default || required;
+                    if (typeof helper === 'function') {
+                        engine.module.registerHelper(name, helper);
+                    }
+                }
+                catch (err) {
+                    console.warn('WARNING: vision failed to load helper \'%s\': %s', file, err.message);
+                }
+            });
+        });
+    }
+
+
+    _prepare(template, options, callback) {
+
+        options = options || {};
+
+        const fileExtension = Path.extname(template).slice(1);
+        const extension = fileExtension || this._defaultExtension;
+        if (!extension) {
+            return callback(Boom.badImplementation('Unknown extension and no defaultExtension configured for view template: ' + template));
+        }
+
+        const engine = this._engines[extension];
+        if (!engine) {
+            return callback(Boom.badImplementation('No view engine found for file: ' + template));
+        }
+
+        template = template + (fileExtension ? '' : engine.suffix);
+
+        // Engine is ready to render
+
+        if (engine.ready) {
+            return this._prepareTemplates(template, engine, options, callback);
+        }
+
+        // Engine needs initialization
+
+        return this._prepareEngine(engine, (err) => {
 
             if (err) {
                 return callback(err);
             }
 
-            compiled.template = compiledTemplate;
+            return this._prepareTemplates(template, engine, options, callback);
+        });
+    }
 
-            // No layout
 
-            if (!compiled.settings.layout) {
-                return callback(null, compiled);
+    _prepareEngine(engine, next) {
+
+        // _prepareEngine can only be invoked when the prepare function is defined
+
+        try {
+            return engine.module.prepare(engine.config, (err) => {
+
+                if (err) {
+                    return next(err);
+                }
+
+                engine.ready = true;
+                return next();
+            });
+        }
+        catch (err) {
+            return next(err);
+        }
+    }
+
+
+    _prepareTemplates(template, engine, options, callback) {
+
+        const compiled = {
+            settings: Hoek.applyToDefaults(engine.config, options)
+        };
+
+        this._path(template, compiled.settings, false, (err, templatePath) => {
+
+            if (err) {
+                return callback(err);
             }
 
-            // With layout
+            if (!engine.config.isCached) {
+                this._loadPartials(engine);
+                this._loadHelpers(engine);
+            }
 
-            this._path((compiled.settings.layout === true ? 'layout' : compiled.settings.layout) + engine.suffix, compiled.settings, true, (err, layoutPath) => {
+            this._compile(templatePath, engine, compiled.settings, (err, compiledTemplate) => {
 
                 if (err) {
                     return callback(err);
                 }
 
-                this._compile(layoutPath, engine, compiled.settings, (err, layout) => {
+                compiled.template = compiledTemplate;
+
+                // No layout
+
+                if (!compiled.settings.layout) {
+                    return callback(null, compiled);
+                }
+
+                // With layout
+
+                this._path((compiled.settings.layout === true ? 'layout' : compiled.settings.layout) + engine.suffix, compiled.settings, true, (err, layoutPath) => {
 
                     if (err) {
                         return callback(err);
                     }
 
-                    compiled.layout = layout;
-                    return callback(null, compiled);
+                    this._compile(layoutPath, engine, compiled.settings, (err, layout) => {
+
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        compiled.layout = layout;
+                        return callback(null, compiled);
+                    });
                 });
             });
         });
-    });
-};
-
-
-internals.Manager.prototype._path = function (template, settings, isLayout, next) {
-
-    // Validate path
-
-    const isAbsolutePath = Path.isAbsolute(template);
-    const isInsecurePath = template.match(/\.\.\//g);
-
-    if (!settings.allowAbsolutePaths &&
-        isAbsolutePath) {
-
-        return next(Boom.badImplementation('Absolute paths are not allowed in views'));
     }
 
-    if (!settings.allowInsecureAccess &&
-        isInsecurePath) {
 
-        return next(Boom.badImplementation('View paths cannot lookup templates outside root path (path includes one or more \'../\')'));
-    }
+    _path(template, settings, isLayout, next) {
 
-    // Resolve path and extension
+        // Validate path
 
-    let paths;
-    if (isAbsolutePath) {
-        paths = [template];
-    }
-    else {
-        paths = [].concat((isLayout && settings.layoutPath) || settings.path);
+        const isAbsolutePath = Path.isAbsolute(template);
+        const isInsecurePath = template.match(/\.\.\//g);
 
-        for (let i = 0; i < paths.length; ++i) {
-            paths[i] = internals.path(settings.relativeTo, paths[i], template);
+        if (!settings.allowAbsolutePaths &&
+            isAbsolutePath) {
+
+            return next(Boom.badImplementation('Absolute paths are not allowed in views'));
         }
-    }
 
-    Items.serial(paths, (path, nextFile) => {
+        if (!settings.allowInsecureAccess &&
+            isInsecurePath) {
 
-        Fs.stat(path, (err, stats) => {
+            return next(Boom.badImplementation('View paths cannot lookup templates outside root path (path includes one or more \'../\')'));
+        }
 
-            if (!err &&
-                stats.isFile()) {
+        // Resolve path and extension
 
-                return next(null, path);
+        let paths;
+        if (isAbsolutePath) {
+            paths = [template];
+        }
+        else {
+            paths = [].concat((isLayout && settings.layoutPath) || settings.path);
+
+            for (let i = 0; i < paths.length; ++i) {
+                paths[i] = internals.path(settings.relativeTo, paths[i], template);
             }
+        }
 
-            return nextFile();
+        Items.serial(paths, (path, nextFile) => {
+
+            Fs.stat(path, (err, stats) => {
+
+                if (!err &&
+                    stats.isFile()) {
+
+                    return next(null, path);
+                }
+
+                return nextFile();
+            });
+        }, () => {
+
+            return next(Boom.badImplementation('View file not found: `' + template + '`. Locations searched: [' + paths.join(',') + ']'));
         });
-    }, () => {
-
-        return next(Boom.badImplementation('View file not found: `' + template + '`. Locations searched: [' + paths.join(',') + ']'));
-    });
-};
+    }
 
 
-internals.Manager.prototype._render = function (compiled, context, request, callback) {
+    _compile(template, engine, settings, callback) {
 
-    if (this._context) {
-        let base = typeof this._context === 'function' ? this._context(request) : this._context;
-        if (context) {
-            base = Hoek.shallow(base);
-            const keys = Object.keys(context);
-            for (let i = 0; i < keys.length; ++i) {
-                const key = keys[i];
-                base[key] = context[key];
+        if (engine.cache &&
+            engine.cache[template]) {
+
+            return callback(null, engine.cache[template]);
+        }
+
+        settings.compileOptions.filename = template;            // Pass the template to Pug via this copy of compileOptions
+
+        // Read file
+
+        Fs.readFile(template, { encoding: settings.encoding }, (err, data) => {
+
+            if (err) {
+                return callback(Boom.badImplementation('Failed to read view file: ' + template));
             }
-        }
 
-        context = base;
+            engine.compileFunc(data, settings.compileOptions, (err, compiled) => {
+
+                if (err) {
+                    return callback(Boom.boomify(err));
+                }
+
+                if (engine.cache) {
+                    engine.cache[template] = compiled;
+                }
+
+                return callback(null, compiled);
+            });
+        });
     }
 
-    context = context || {};
 
-    if (compiled.layout &&
-        context.hasOwnProperty(compiled.settings.layoutKeyword)) {
+    _render(compiled, context, request, callback) {
 
-        return callback(Boom.badImplementation('settings.layoutKeyword conflict', { context, keyword: compiled.settings.layoutKeyword }));
-    }
+        if (this._context) {
+            let base = typeof this._context === 'function' ? this._context(request) : this._context;
+            if (context) {
+                base = Hoek.shallow(base);
+                const keys = Object.keys(context);
+                for (let i = 0; i < keys.length; ++i) {
+                    const key = keys[i];
+                    base[key] = context[key];
+                }
+            }
 
-    compiled.template(context, compiled.settings.runtimeOptions, (err, renderedContent) => {
-
-        if (err) {
-            return callback(Boom.badImplementation(err.message, err));
+            context = base;
         }
 
-        // No layout
+        context = context || {};
 
-        if (!compiled.layout) {
-            return callback(null, renderedContent);
+        if (compiled.layout &&
+            context.hasOwnProperty(compiled.settings.layoutKeyword)) {
+
+            return callback(Boom.badImplementation('settings.layoutKeyword conflict', { context, keyword: compiled.settings.layoutKeyword }));
         }
 
-        // With layout
-
-        context[compiled.settings.layoutKeyword] = renderedContent;
-        compiled.layout(context, compiled.settings.runtimeOptions, (err, renderedWithLayout) => {
-
-            delete context[compiled.settings.layoutKeyword];
+        compiled.template(context, compiled.settings.runtimeOptions, (err, renderedContent) => {
 
             if (err) {
                 return callback(Boom.badImplementation(err.message, err));
             }
 
-            return callback(null, renderedWithLayout);
+            // No layout
+
+            if (!compiled.layout) {
+                return callback(null, renderedContent);
+            }
+
+            // With layout
+
+            context[compiled.settings.layoutKeyword] = renderedContent;
+            compiled.layout(context, compiled.settings.runtimeOptions, (err, renderedWithLayout) => {
+
+                delete context[compiled.settings.layoutKeyword];
+
+                if (err) {
+                    return callback(Boom.badImplementation(err.message, err));
+                }
+
+                return callback(null, renderedWithLayout);
+            });
         });
-    });
+    }
+
+
+    _response(template, context, options, request) {
+
+        Joi.assert(options, Schemas.viewOverride);
+
+        const source = { manager: this, template, context, options };
+        return request.generateResponse(source, { variety: 'view', marshal: internals.marshal, prepare: internals.prepare });
+    }
+
+
+    registerHelper(name, helper) {
+
+        Object.keys(this._engines).forEach((extension) => {
+
+            const engine = this._engines[extension];
+
+            if (typeof engine.module.registerHelper === 'function') {
+                engine.module.registerHelper(name, helper);
+            }
+        });
+    }
+
+
+    render(filename, context, options, request) {
+
+        return new Promise((resolve, reject) => {
+
+            this._prepare(filename, options, (err, compiled) => {
+
+                if (err) {
+                    return reject(err);
+                }
+
+                this._render(compiled, context, request, (err, rendered) => {
+
+                    if (err) {
+                        return reject(err);
+                    }
+
+                    return resolve(rendered);
+                });
+            });
+        });
+    }
 };
 
 
@@ -491,49 +537,6 @@ internals.path = function (base, path, file) {
     }
 
     return Path.join(base || '', path || '', file || '');
-};
-
-
-internals.Manager.prototype._compile = function (template, engine, settings, callback) {
-
-    if (engine.cache &&
-        engine.cache[template]) {
-
-        return callback(null, engine.cache[template]);
-    }
-
-    settings.compileOptions.filename = template;            // Pass the template to Pug via this copy of compileOptions
-
-    // Read file
-
-    Fs.readFile(template, { encoding: settings.encoding }, (err, data) => {
-
-        if (err) {
-            return callback(Boom.badImplementation('Failed to read view file: ' + template));
-        }
-
-        engine.compileFunc(data, settings.compileOptions, (err, compiled) => {
-
-            if (err) {
-                return callback(Boom.boomify(err));
-            }
-
-            if (engine.cache) {
-                engine.cache[template] = compiled;
-            }
-
-            return callback(null, compiled);
-        });
-    });
-};
-
-
-internals.Manager.prototype._response = function (template, context, options, request) {
-
-    Joi.assert(options, Schemas.viewOverride);
-
-    const source = { manager: this, template, context, options };
-    return request.generateResponse(source, { variety: 'view', marshal: internals.marshal, prepare: internals.prepare });
 };
 
 


### PR DESCRIPTION
The diff on this PR is not very helpful at all
What I did was turn the Manager into a class and all of the `internals.manager.prototype.this` and `internals.manager.prototype.that` functions are class functions now.

The tests haven't been touched