### PR TITLE
WIP provide method to get engine config, fixes #122

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,8 @@ const Manager = require('./manager');
 
 const internals = {};
 
+exports.Manager = Manager;
+
 exports.plugin = {
 
     multiple: true,
@@ -22,144 +24,175 @@ exports.plugin = {
 
     register: function (server, options) {
 
+        return new internals.vision(server, options);
+    }
+};
+
+
+internals.vision = class Vision {
+
+    constructor(server, options) {
+
         if (Object.keys(options).length > 0) {
-            internals.assignManager.call(server, options, server.realm.parent);
+            this.assignManager(server)(options, server.realm.parent);
         }
 
-        const rootRealm = internals.getRootRealm(server.realm);
-        const rootState = internals.state(rootRealm);
+        const rootRealm = this.getRootRealm(server.realm);
+
+        const rootState = this.getState(rootRealm);
 
         if (rootState.setup) {
             return;
         }
 
-        server.decorate('server', 'views', internals.assignManager);
-        server.decorate('server', 'render', internals.render);
-        server.decorate('request', 'render', internals.render);
-        server.decorate('handler', 'view', internals.handler);
-        server.decorate('toolkit', 'view', internals.toolkitView);
+        server.decorate('server', 'views', this.assignManager(server));
+        server.decorate('server', 'render', this.render(server));
+        server.decorate('request', 'render', this.render(server));
+        server.decorate('handler', 'view', this.handler(server));
+        server.decorate('toolkit', 'view', this.toolkitView(server));
 
         rootState.setup = true;
     }
-};
 
+    assignManager(rootServer) {
 
-internals.assignManager = function (options, realm) {
+        const self = this;
 
-    realm = realm || this.realm;
-    const realmState = internals.state(realm);
+        return function (options, realm) {
 
-    Hoek.assert(!realmState.manager, 'Cannot set views manager more than once per realm');
+            realm = realm || this.realm;
 
-    if (!options.relativeTo &&
-        realm.settings.files.relativeTo) {
+            const realmState = self.getState(realm);
 
-        options = Hoek.shallow(options);
-        options.relativeTo = realm.settings.files.relativeTo;
-    }
+            Hoek.assert(!realmState.manager, 'Cannot set views manager more than once per realm');
 
-    const manager = new Manager(options);
-    realmState.manager = manager;
-    return manager;
-};
+            if (!options.relativeTo &&
+                realm.settings.files.relativeTo) {
 
-
-internals.render = async function (template, context, options = {}) {
-
-    const isServer = (typeof this.route === 'function');
-    const realm = (isServer ? this.realm : this.route.realm);
-
-    const manager = internals.nearestManager(realm);
-    Hoek.assert(manager, 'Missing views manager');
-
-    if (!isServer) {
-        // this is the request
-        return await manager.render(template, context, options, this);
-    }
-
-    return await manager.render(template, context, options);
-};
-
-
-internals.toolkitView = function (template, context, options) {
-
-    const manager = internals.nearestManager(this.realm);
-
-    Hoek.assert(manager, 'Missing views manager');
-    return this.response(manager._response(template, context, options, this.request));
-};
-
-
-internals.handler = function (route, options) {
-
-    Joi.assert(options, Schemas.handler, 'Invalid view handler options (' + route.path + ')');
-
-    if (typeof options === 'string') {
-        options = { template: options };
-    }
-
-    const settings = {                                                // Shallow copy to allow making dynamic changes to context
-        template: options.template,
-        context: options.context,
-        options: options.options
-    };
-
-    return function (request, h) {
-
-        const context = {
-            params: request.params,
-            payload: request.payload,
-            query: request.query,
-            pre: request.pre
-        };
-
-        if (settings.context) {                                     // Shallow copy to avoid cloning unknown objects
-            const keys = Object.keys(settings.context);
-            for (let i = 0; i < keys.length; ++i) {
-                const key = keys[i];
-                context[key] = settings.context[key];
+                options = Hoek.shallow(options);
+                options.relativeTo = realm.settings.files.relativeTo;
             }
+
+            const manager = new Manager(options);
+            realmState.manager = manager;
+            return manager;
+        };
+    }
+
+
+    render(rootServer) {
+
+        const self = this;
+
+        return async function (template, context, options = {}) {
+
+            const isServer = internals.isServer(this);
+            const realm = (isServer ? this.realm : this.route.realm);
+
+            const manager = self.nearestManager(realm);
+            Hoek.assert(manager, 'Missing views manager');
+
+            if (!isServer) {
+                // this is the request
+                return await manager.render(template, context, options, this);
+            }
+
+            return await manager.render(template, context, options);
+        };
+    }
+
+
+    toolkitView(rootServer) {
+
+        const self = this;
+
+        return function (template, context, options) {
+
+            const manager = self.nearestManager(this.realm);
+
+            Hoek.assert(manager, 'Missing views manager');
+
+            return this.response(manager._response(template, context, options, this.request));
+        };
+    }
+
+
+    handler(rootServer) {
+
+        return function (route, options) {
+
+            Joi.assert(options, Schemas.handler, 'Invalid view handler options (' + route.path + ')');
+
+            if (typeof options === 'string') {
+                options = { template: options };
+            }
+
+            const settings = {                                                // Shallow copy to allow making dynamic changes to context
+                template: options.template,
+                context: options.context,
+                options: options.options
+            };
+
+            return function (request, h) {
+
+                const context = {
+                    params: request.params,
+                    payload: request.payload,
+                    query: request.query,
+                    pre: request.pre
+                };
+
+                if (settings.context) {                                     // Shallow copy to avoid cloning unknown objects
+                    const keys = Object.keys(settings.context);
+                    for (let i = 0; i < keys.length; ++i) {
+                        const key = keys[i];
+                        context[key] = settings.context[key];
+                    }
+                }
+
+                return h.view(settings.template, context, settings.options);
+            };
+        };
+    }
+
+
+    getState(realm) {
+
+        const state = realm.plugins.vision = realm.plugins.vision || {};
+        return state;
+    }
+
+
+    nearestManager(realm) {
+
+        const pluginState = this.getState(realm);
+        if (pluginState.manager) {
+            return pluginState.manager;
         }
 
-        return h.view(settings.template, context, settings.options);
-    };
-};
+        let parent = realm.parent;
+        while (parent) {
 
+            const parentState = this.getState(parent);
+            if (parentState.manager) {
+                return parentState.manager;
+            }
 
-internals.state = (realm) => {
-
-    const state = realm.plugins.vision = realm.plugins.vision || {};
-    return state;
-};
-
-
-internals.nearestManager = function (realm) {
-
-    const pluginState = internals.state(realm);
-    if (pluginState.manager) {
-        return pluginState.manager;
-    }
-
-    let parent = realm.parent;
-    while (parent) {
-
-        const parentState = internals.state(parent);
-        if (parentState.manager) {
-            return parentState.manager;
+            parent = parent.parent;
         }
 
-        parent = parent.parent;
+        return null;
     }
 
-    return null;
-};
 
+    getRootRealm(realm) {
 
-internals.getRootRealm = (realm) => {
+        while (realm.parent) {
+            realm = realm.parent;
+        }
 
-    while (realm.parent) {
-        realm = realm.parent;
+        return realm;
     }
-
-    return realm;
 };
+
+internals.isServer = (ref) => (typeof ref.route === 'function');

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,6 @@ const Manager = require('./manager');
 
 const internals = {};
 
-exports.Manager = Manager;
-
 exports.plugin = {
 
     multiple: true,
@@ -29,7 +27,7 @@ exports.plugin = {
 };
 
 
-internals.vision = class Vision {
+const Vision = internals.vision = class Vision {
 
     constructor(server, options) {
 
@@ -39,7 +37,7 @@ internals.vision = class Vision {
 
         const rootRealm = this.getRootRealm(server.realm);
 
-        const rootState = this.getState(rootRealm);
+        const rootState = Vision.getState(rootRealm);
 
         if (rootState.setup) {
             return;
@@ -54,15 +52,43 @@ internals.vision = class Vision {
         rootState.setup = true;
     }
 
-    assignManager(rootServer) {
 
-        const self = this;
+    static getState(realm) {
+
+        const state = realm.plugins.vision = realm.plugins.vision || {};
+        return state;
+    }
+
+
+    static getNearestManager(realm) {
+
+        const pluginState = Vision.getState(realm);
+        if (pluginState.manager) {
+            return pluginState.manager;
+        }
+
+        let parent = realm.parent;
+        while (parent) {
+
+            const parentState = Vision.getState(parent);
+            if (parentState.manager) {
+                return parentState.manager;
+            }
+
+            parent = parent.parent;
+        }
+
+        return null;
+    }
+
+
+    assignManager(rootServer) {
 
         return function (options, realm) {
 
             realm = realm || this.realm;
 
-            const realmState = self.getState(realm);
+            const realmState = Vision.getState(realm);
 
             Hoek.assert(!realmState.manager, 'Cannot set views manager more than once per realm');
 
@@ -82,14 +108,12 @@ internals.vision = class Vision {
 
     render(rootServer) {
 
-        const self = this;
-
         return async function (template, context, options = {}) {
 
             const isServer = internals.isServer(this);
             const realm = (isServer ? this.realm : this.route.realm);
 
-            const manager = self.nearestManager(realm);
+            const manager = Vision.getNearestManager(realm);
             Hoek.assert(manager, 'Missing views manager');
 
             if (!isServer) {
@@ -104,11 +128,9 @@ internals.vision = class Vision {
 
     toolkitView(rootServer) {
 
-        const self = this;
-
         return function (template, context, options) {
 
-            const manager = self.nearestManager(this.realm);
+            const manager = Vision.getNearestManager(this.realm);
 
             Hoek.assert(manager, 'Missing views manager');
 
@@ -156,35 +178,6 @@ internals.vision = class Vision {
     }
 
 
-    getState(realm) {
-
-        const state = realm.plugins.vision = realm.plugins.vision || {};
-        return state;
-    }
-
-
-    nearestManager(realm) {
-
-        const pluginState = this.getState(realm);
-        if (pluginState.manager) {
-            return pluginState.manager;
-        }
-
-        let parent = realm.parent;
-        while (parent) {
-
-            const parentState = this.getState(parent);
-            if (parentState.manager) {
-                return parentState.manager;
-            }
-
-            parent = parent.parent;
-        }
-
-        return null;
-    }
-
-
     getRootRealm(realm) {
 
         while (realm.parent) {
@@ -194,5 +187,33 @@ internals.vision = class Vision {
         return realm;
     }
 };
+
+
+exports.getManager = (ref, request) => {
+
+    const errMsg = 'Must pass a server, request, or realm to "Vision.getManager"';
+
+    if (!ref) {
+        throw new Error(errMsg);
+    }
+
+    let realm;
+
+    if (ref.server) {
+        realm = ref.server.realm;
+    }
+    else if (ref.realm) {
+        realm = ref.realm;
+    }
+    else if (ref.plugins) {
+        realm = ref;
+    }
+    else {
+        throw new Error(errMsg);
+    }
+
+    return Vision.getNearestManager(realm);
+};
+
 
 internals.isServer = (ref) => (typeof ref.route === 'function');

--- a/lib/index.js
+++ b/lib/index.js
@@ -189,7 +189,7 @@ const Vision = internals.vision = class Vision {
 };
 
 
-exports.getManager = (ref, request) => {
+exports.getManager = (ref) => {
 
     const errMsg = 'Must pass a server, request, or realm to "Vision.getManager"';
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -39,6 +39,16 @@ module.exports = class Manager {
 
         Joi.assert(options, Schemas.manager);
 
+        this.settings = {
+
+        };
+
+        this._init(options);
+    }
+
+
+    _init(options) {
+
         // Save non-defaults values
 
         const engines = options.engines;
@@ -213,7 +223,7 @@ module.exports = class Manager {
 
                 try {
                     if (!engine.config.isCached) {
-                        delete require.cache[require.resolve(file)]; // bust require's cache
+                        internals.bustRequireCache(file);
                     }
 
                     const required = require(file);
@@ -582,4 +592,10 @@ internals.prepare = function (response) {
             return resolve(response);
         });
     });
+};
+
+
+internals.bustRequireCache = function (file) {
+
+    delete require.cache[require.resolve(file)]; // bust require's cache
 };

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -501,6 +501,31 @@ module.exports = class Manager {
     }
 
 
+    getExtensionConfig(ext) {
+
+        let extension = ext;
+
+        const extensionKeys = Object.keys(this._engines);
+
+        if (!ext) {
+
+            if (extensionKeys.length > 1) {
+                throw new Error('Must provide extension or must use only one extension in views options');
+            }
+            extension = this._engines[extensionKeys[0]];
+        }
+        else {
+            extension = this._engines[ext];
+
+            if (!extension) {
+                throw new Error(`Extension "${ext}" not found on manager`);
+            }
+        }
+
+        return extension.config;
+    }
+
+
     registerHelper(name, helper) {
 
         Object.keys(this._engines).forEach((extension) => {

--- a/test/index.js
+++ b/test/index.js
@@ -271,7 +271,7 @@ describe('render()', () => {
             register: async function (server, options) {
 
                 server.views({
-                    engines: { 'html': Handlebars },
+                    engines: { html: Handlebars },
                     relativeTo: Path.join(__dirname, '/templates/plugin')
                 });
 
@@ -304,7 +304,7 @@ describe('render()', () => {
         await server.register(Vision);
 
         server.views({
-            engines: { 'html': Handlebars },
+            engines: { html: Handlebars },
             relativeTo: Path.join(__dirname, '/templates/plugin')
         });
 
@@ -321,7 +321,7 @@ describe('render()', () => {
             register: async function (server, options) {
 
                 server.views({
-                    engines: { 'html': Handlebars }
+                    engines: { html: Handlebars }
                 });
 
                 const rendered = await server.render('test', { message: 'steve' }, { relativeTo: Path.join(__dirname, '/templates/plugin') });
@@ -353,7 +353,7 @@ describe('render()', () => {
             register: function (server, options) {
 
                 server.views({
-                    engines: { 'html': Handlebars },
+                    engines: { html: Handlebars },
                     relativeTo: Path.join(__dirname, '/templates/plugin')
                 });
 
@@ -444,7 +444,7 @@ describe('views()', () => {
                 await server.register(Vision);
 
                 const views = {
-                    engines: { 'html': Handlebars },
+                    engines: { html: Handlebars },
                     path: './templates/plugin'
                 };
 
@@ -474,7 +474,7 @@ describe('views()', () => {
             register: function (server, options) {
 
                 server.views({
-                    engines: { 'html': Handlebars },
+                    engines: { html: Handlebars },
                     relativeTo: Path.join(__dirname, '/templates/plugin')
                 });
 
@@ -502,7 +502,7 @@ describe('views()', () => {
                 await server.register(Vision);
 
                 const views = {
-                    engines: { 'html': Handlebars },
+                    engines: { html: Handlebars },
                     path: './templates/plugin2'
                 };
 
@@ -529,7 +529,7 @@ describe('views()', () => {
         await server.register({ plugin: test, options: { message: 'viewing it' } });
 
         server.views({
-            engines: { 'html': Handlebars },
+            engines: { html: Handlebars },
             path: __dirname + '/templates/valid'
         });
 
@@ -566,7 +566,7 @@ describe('views()', () => {
         server.path(__dirname);
 
         server.views({
-            engines: { 'html': Handlebars },
+            engines: { html: Handlebars },
             path: './templates/plugin'
         });
 
@@ -579,10 +579,10 @@ describe('views()', () => {
 
         const server = Hapi.server();
         await server.register(Vision);
-        server.views({ engines: { 'html': Handlebars } });
+        server.views({ engines: { html: Handlebars } });
         expect(() => {
 
-            server.views({ engines: { 'html': Handlebars } });
+            server.views({ engines: { html: Handlebars } });
         }).to.throw('Cannot set views manager more than once per realm');
     });
 
@@ -592,7 +592,7 @@ describe('views()', () => {
         await server.register(Vision);
 
         const manager = server.views({
-            engines: { 'html': Handlebars.create() },
+            engines: { html: Handlebars.create() },
             relativeTo: 'test/templates',
             path: 'valid'
         });
@@ -610,7 +610,7 @@ describe('views()', () => {
         await server.register(Vision);
 
         const manager = server.views({
-            engines: { 'html': Handlebars },
+            engines: { html: Handlebars },
             relativeTo: 'test/templates',
             path: 'valid'
         });
@@ -629,7 +629,7 @@ describe('Vision module', () => {
 
         // rootServer.views returns the manager
         const rootViewsManager = rootServer.views({
-            engines: { 'html': Handlebars },
+            engines: { html: Handlebars },
             relativeTo: Path.join(__dirname, '/templates'),
             path: 'valid'
         });
@@ -646,7 +646,7 @@ describe('Vision module', () => {
                 oneRealm = server.realm;
 
                 oneViewsManager = server.views({
-                    engines: { 'html': Handlebars },
+                    engines: { html: Handlebars },
                     relativeTo: Path.join(__dirname, '/templates'),
                     path: 'plugin'
                 });
@@ -707,7 +707,7 @@ describe('Plugin', () => {
                 await server.register({
                     plugin: Vision,
                     options: {
-                        engines: { 'html': Handlebars },
+                        engines: { html: Handlebars },
                         relativeTo: Path.join(__dirname, '/templates'),
                         path: 'plugin'
                     }
@@ -731,7 +731,7 @@ describe('Plugin', () => {
                 await server.register({
                     plugin: Vision,
                     options: {
-                        engines: { 'html': Handlebars },
+                        engines: { html: Handlebars },
                         relativeTo: Path.join(__dirname, '/templates'),
                         path: 'plugin'
                     }
@@ -754,7 +754,7 @@ describe('Plugin', () => {
         await server.register({
             plugin: Vision,
             options: {
-                engines: { 'html': Handlebars },
+                engines: { html: Handlebars },
                 relativeTo: Path.join(__dirname, '/templates'),
                 path: 'valid'
             }
@@ -778,6 +778,71 @@ describe('Plugin', () => {
         expect(resRootServer.result).to.equal('<div>\n    <h1>Root Server</h1>\n</div>\n');
     });
 
+    it('manager gives config via "getExtensionConfig"', async () => {
+
+        const rootServer = Hapi.server();
+
+        const relativeToPath = 'test/templates';
+
+        await rootServer.register({
+            plugin: Vision,
+            options: {
+                engines: { html: Handlebars.create() },
+                relativeTo: relativeToPath,
+                path: 'valid'
+            }
+        });
+
+        const one = {
+            name: 'one',
+            register: async function (server, options) {
+
+                await server.register({
+                    plugin: Vision,
+                    options: {
+                        engines: {
+                            html: Handlebars,
+                            pug: Pug
+                        },
+                        relativeTo: Path.join(__dirname, '/templates'),
+                        path: 'plugin'
+                    }
+                });
+
+                const manager = Vision.getManager(server);
+
+                expect(() => {
+
+                    manager.getExtensionConfig();
+                }).to.throw(/Must provide extension or must use only one extension in views options/);
+
+                expect(() => {
+
+                    manager.getExtensionConfig('bogusExtension');
+                }).to.throw('Extension "bogusExtension" not found on manager');
+
+                server.route({
+                    path: '/viewPluginOne',
+                    method: 'GET',
+                    handler: (request, h) => {
+
+                        return h.view('test', { message: 'Plugin One' });
+                    }
+                });
+            }
+        };
+
+        await rootServer.register(one);
+
+        const rootManager = Vision.getManager(rootServer);
+
+        const htmlConfig = rootManager.getExtensionConfig();
+        const htmlConfigByKey = rootManager.getExtensionConfig('html');
+
+        expect(htmlConfig.relativeTo).to.equal(relativeToPath);
+        expect(htmlConfig).to.equal(htmlConfigByKey);
+    });
+
     it('passes plugin options to manager', async () => {
 
         const server = Hapi.server();
@@ -785,7 +850,7 @@ describe('Plugin', () => {
         await server.register({
             plugin: Vision,
             options: {
-                engines: { 'html': Handlebars },
+                engines: { html: Handlebars },
                 relativeTo: Path.join(__dirname, '/templates'),
                 path: 'valid'
             }
@@ -821,7 +886,7 @@ describe('Plugin', () => {
                 await server.register({
                     plugin: Vision,
                     options: {
-                        engines: { 'html': Handlebars },
+                        engines: { html: Handlebars },
                         relativeTo: Path.join(__dirname, '/templates'),
                         path: 'plugin2'
                     }
@@ -847,7 +912,7 @@ describe('Plugin', () => {
                 await server.register(Vision);
 
                 server.views({
-                    engines: { 'html': Handlebars },
+                    engines: { html: Handlebars },
                     relativeTo: Path.join(__dirname, '/templates'),
                     path: 'plugin3'
                 });
@@ -900,7 +965,7 @@ describe('Plugin', () => {
         await server.register({
             plugin: Vision,
             options: {
-                engines: { 'html': Handlebars },
+                engines: { html: Handlebars },
                 relativeTo: Path.join(__dirname, '/templates'),
                 path: 'valid'
             }


### PR DESCRIPTION
- Provide method `getExtensionConfig` on the manager to get an extension's config. Useful for determining template paths and see other options passed
- Normalize styles around the `engine` object in tests (remove single quotes around 'html')

- Solves #122 to get the template directory for a given engine via this api _which will most likely change to a decorator instead of grabbing off the Vision module_

```
const htmlConfig = Vision.getManager(server).getExtensionConfig('html');
const templateDirectory = htmlConfig.relativeTo + htmlConfig.path;
```