### PR TITLE
Fix for memory leak cause by issue #171

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -640,5 +640,16 @@ internals.prepare = function (response) {
 
 internals.bustRequireCache = function (path) {
 
-    delete require.cache[require.resolve(path)];
+    const mod = require.cache[require.resolve(path)];
+    if (mod) {
+        // remove module from require cache
+        delete require.cache[require.resolve(path)];
+
+        // remove module references from parent module
+        let ix = mod.parent.children.indexOf(mod);
+        while (ix>=0) {
+            mod.parent.children.splice(ix, 1);
+            ix = mod.parent.children.indexOf(mod);
+        }
+    }
 };

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -217,7 +217,7 @@ module.exports = class Manager {
 
                 try {
                     if (!engine.config.isCached) {
-                        internals.bustRequireCache(file);
+                        this._bustRequireCache(file);
                     }
 
                     const required = require(file);
@@ -495,6 +495,20 @@ module.exports = class Manager {
         return request.generateResponse(source, { variety: 'view', marshal: internals.marshal, prepare: internals.prepare });
     }
 
+    _bustRequireCache(path) {
+
+        const modulekey = require.resolve(path);
+        const mod = require.cache[modulekey];
+
+        if (mod) {
+            // Remove module from require cache
+            delete require.cache[modulekey];
+
+            // Remove module references from parent module
+            mod.parent.children = mod.parent.children.filter((el) => el !== mod);
+        }
+    }
+
 
     getEngine(ext) {
 
@@ -635,18 +649,4 @@ internals.prepare = function (response) {
             return resolve(response);
         });
     });
-};
-
-
-internals.bustRequireCache = function (path) {
-
-    const modulekey = require.resolve(path);
-    const mod = require.cache[modulekey];
-    if (mod) {
-        // Remove module from require cache
-        delete require.cache[modulekey];
-
-        // Remove module references from parent module
-        mod.parent.children = mod.parent.children.filter((el) => el !== mod);
-    }
 };

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -640,16 +640,13 @@ internals.prepare = function (response) {
 
 internals.bustRequireCache = function (path) {
 
-    const mod = require.cache[require.resolve(path)];
+    const modulekey = require.resolve(path);
+    const mod = require.cache[modulekey];
     if (mod) {
         // Remove module from require cache
-        delete require.cache[require.resolve(path)];
+        delete require.cache[modulekey];
 
         // Remove module references from parent module
-        let ix = mod.parent.children.indexOf(mod);
-        while (ix>=0) {
-            mod.parent.children.splice(ix, 1);
-            ix = mod.parent.children.indexOf(mod);
-        }
+        mod.parent.children = mod.parent.children.filter((el) => el !== mod);
     }
 };

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -642,10 +642,10 @@ internals.bustRequireCache = function (path) {
 
     const mod = require.cache[require.resolve(path)];
     if (mod) {
-        // remove module from require cache
+        // Remove module from require cache
         delete require.cache[require.resolve(path)];
 
-        // remove module references from parent module
+        // Remove module references from parent module
         let ix = mod.parent.children.indexOf(mod);
         while (ix>=0) {
             mod.parent.children.splice(ix, 1);

--- a/test/manager.js
+++ b/test/manager.js
@@ -2117,4 +2117,57 @@ describe('Manager', () => {
             expect(res.payload).to.contain('<h1>global</h1>');
         });
     });
+
+    describe('_bustRequireChache()', () => {
+
+        it('check that if a file was loaded and is in cache - it is removed correctly', () => {
+
+            const modulePath = Path.resolve(__dirname, 'testModule');
+            require(modulePath);
+            const options = {
+                engines: {
+                    html: {
+                        module: require('handlebars'),
+                        path: __dirname + '/templates/valid'
+                    }
+                },
+                context: {
+                    a: 1
+                }
+            };
+
+            const manager = new Manager(options);
+            const moduleKey = require.resolve(modulePath);
+            const moduleRef = require.cache[moduleKey];
+
+            expect(require.cache[moduleKey]).to.exist();
+            const parentRef = require.cache[moduleKey].parent;
+            expect(parentRef.children).to.include(moduleRef);
+            manager._bustRequireCache(modulePath);
+            expect(require.cache[moduleKey]).to.not.exist();
+            expect(parentRef.children).to.not.include(moduleRef);
+        });
+
+        it('calling with module that was already removed does not throw', () => {
+
+            const modulePath = Path.resolve(__dirname, 'testModule');
+            require(modulePath);
+            const options = {
+                engines: {
+                    html: {
+                        module: require('handlebars'),
+                        path: __dirname + '/templates/valid'
+                    }
+                },
+                context: {
+                    a: 1
+                }
+            };
+
+            const manager = new Manager(options);
+            manager._bustRequireCache(modulePath);
+            expect(manager._bustRequireCache.bind(manager,modulePath)).to.not.throw();
+
+        });
+    });
 });

--- a/test/testModule.js
+++ b/test/testModule.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = {};


### PR DESCRIPTION
#171 The change here is in the `bustRequireCache` method. In addition to deleting the module from the cache, all the references are also removed from the parent module.