### PR TITLE
Update Pug documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ provision();
 const Hapi = require('hapi');
 const Vision = require('vision');
 const Pug = require('pug');
+const Path = require('path');
 
 const server = Hapi.Server({ port: 3000 });
 
@@ -175,7 +176,10 @@ const provision = async () => {
     server.views({
         engines: { pug: Pug },
         relativeTo: __dirname,
-        path: 'examples/pug/templates'
+        path: 'examples/pug/templates',
+        compileOptions: {
+            basedir: Path.join(__dirname, 'examples/pug/templates'),
+        }
     });
 
     server.route({ method: 'GET', path: '/', handler: rootHandler });

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ const provision = async () => {
         compileOptions: {
             // By default Pug uses relative paths (e.g. ../root.pug), when using absolute paths (e.g. include /root.pug), basedir is prepended.
             // https://pugjs.org/language/includes.html
-            basedir: Path.join(__dirname, 'examples/pug/templates'),
+            basedir: Path.join(__dirname, 'examples/pug/templates')
         }
     });
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ const provision = async () => {
         relativeTo: __dirname,
         path: 'examples/pug/templates',
         compileOptions: {
+            // By default Pug uses relative paths (e.g. ../root.pug), when using absolute paths (e.g. include /root.pug), basedir is prepended.
+            // https://pugjs.org/language/includes.html
             basedir: Path.join(__dirname, 'examples/pug/templates'),
         }
     });

--- a/examples/pug/index.js
+++ b/examples/pug/index.js
@@ -5,7 +5,6 @@ const Hapi = require('hapi');
 const Vision = require('../..');
 const Path = require('path');
 const Pug = require('pug');
-const Path = require('path');
 
 
 // Declare internals
@@ -40,6 +39,8 @@ internals.main = async () => {
         relativeTo: __dirname,
         path: `templates/${internals.templatePath}`,
         compileOptions: {
+            // By default Pug uses relative paths (e.g. ../root.pug), when using absolute paths (e.g. include /root.pug), basedir is prepended.
+            // https://pugjs.org/language/includes.html
             basedir: Path.join(__dirname, 'examples/pug/templates'),
         }
     });

--- a/examples/pug/index.js
+++ b/examples/pug/index.js
@@ -5,6 +5,7 @@ const Hapi = require('hapi');
 const Vision = require('../..');
 const Path = require('path');
 const Pug = require('pug');
+const Path = require('path');
 
 
 // Declare internals
@@ -37,7 +38,10 @@ internals.main = async () => {
     server.views({
         engines: { pug: Pug },
         relativeTo: __dirname,
-        path: `templates/${internals.templatePath}`
+        path: `templates/${internals.templatePath}`,
+        compileOptions: {
+            basedir: Path.join(__dirname, 'examples/pug/templates'),
+        }
     });
 
     server.route({ method: 'GET', path: '/', handler: rootHandler });

--- a/examples/pug/index.js
+++ b/examples/pug/index.js
@@ -41,7 +41,7 @@ internals.main = async () => {
         compileOptions: {
             // By default Pug uses relative paths (e.g. ../root.pug), when using absolute paths (e.g. include /root.pug), basedir is prepended.
             // https://pugjs.org/language/includes.html
-            basedir: Path.join(__dirname, 'examples/pug/templates'),
+            basedir: Path.join(__dirname, 'examples/pug/templates')
         }
     });
 


### PR DESCRIPTION
Because I've spend a good full day breaking my head over this, I thought it might be a good idea to include how to use `options.basedir` for the Pug documentation. `options.basedir` allows you to use absolute paths when using `includes` or `extend`.

Not sure if this is something that should be included in the documentation, so feel free to reject it. But I think it would definitely help people.