### PR TITLE
fix import typo in README

### DIFF
--- a/API.md
+++ b/API.md
@@ -183,7 +183,7 @@ const internals = {};
 
 internals.provision = async () => {
 
-    await server.register(require('@vision/vision'));
+    await server.register(require('@hapi/vision'));
 
     server.views({
         engines: { html: require('handlebars') },


### PR DESCRIPTION
Just a typo fix, no code changes. Noticed it as I was going over the README.