### PR TITLE
Update Nunjucks example

### DIFF
--- a/examples/nunjucks/index.js
+++ b/examples/nunjucks/index.js
@@ -36,7 +36,7 @@ internals.main = async function () {
             html: {
                 compile: (src, options) => {
 
-                    const template = Nunjucks.compile(src, options.environment);
+                    const template = Nunjucks.compile(src, options.environment, options.filename);
 
                     return (context) => {
 


### PR DESCRIPTION
Include the template filename as a compile param - used in Nunjucks errors