### PR TITLE
update handlebars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "babel-plugin-transform-react-jsx": "6.x.x",
         "coveralls": "3.x.x",
         "ejs": "^3.1.3",
-        "handlebars": "4.x.x",
+        "handlebars": "^4.5.3",
         "hapi-react-views": "10.x.x",
         "marko": "4.x.x",
         "mustache": "^4.0.1",


### PR DESCRIPTION
handlebars is only a devDependency, but update the version due to
a security advisory.

Refs: https://github.com/advisories/GHSA-q2c6-c6pm-g3gh