### PR TITLE
Allow context to return a promise

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -381,10 +381,17 @@ module.exports = class Manager {
         });
     }
 
-    _render(compiled, context, request) {
+    async _render(compiled, context, request) {
 
         if (this._context) {
-            let base = typeof this._context === 'function' ? this._context(request) : this._context;
+            let base;
+            if (typeof this._context === 'function') {
+                base = await Promise.resolve(this._context(request));
+            }
+            else {
+                base = this._context;
+            }
+
             if (context) {
                 base = Object.assign({}, base);             // Shallow cloned
                 const keys = Object.keys(context);


### PR DESCRIPTION
I'm using a function to return a global context, and it needs to look up some things asynchronously. I found that Vision wasn't resolving the promise before continuing with render.

The change I've made fixes that, and the test suite still passes. I'm aware of #177, but that seems to be a wider issue (and has been going on for a while!). Please would you consider merging this?

Thanks!