### PR TITLE
Add example for Etajs

### DIFF
--- a/API.md
+++ b/API.md
@@ -390,7 +390,7 @@ provision();
 
 ```js
 const Hapi = require('@hapi/hapi');
-const Eta = require('Eta');
+const Eta = require('eta');
 const Vision = require('@hapi/vision');
 
 const server = Hapi.Server({ port: 3000 });
@@ -412,7 +412,7 @@ const provision = async () => {
             eta: {
                 compile: (src, options) => {
 
-                    const compiled = Eta.compile(src);
+                    const compiled = Eta.compile(src, options);
 
                     return (context) => {
 
@@ -420,6 +420,16 @@ const provision = async () => {
                     };
                 }
             }
+        },
+        /**
+         * This is the config object that gets passed to the compile function
+         * defined above. This should contain the eta configuration object
+         * described at https://eta.js.org/docs/api/configuration Only some of
+         * the configuration are relevant when using with hapijs.
+         */
+        compileOptions: {
+            autoEscape: true,
+            tags: ['{{', '}}']
         },
         relativeTo: __dirname,
         path: 'examples/eta/templates'

--- a/API.md
+++ b/API.md
@@ -386,6 +386,54 @@ const provision = async () => {
 provision();
 ```
 
+### Eta
+
+```js
+const Hapi = require('@hapi/hapi');
+const Eta = require('Eta');
+const Vision = require('@hapi/vision');
+
+const server = Hapi.Server({ port: 3000 });
+
+const rootHandler = (request, h) => {
+
+    return h.view('index', {
+        title: 'examples/eta/templates | Hapi ' + request.server.version,
+        message: 'Hello Eta!'
+    });
+};
+
+const provision = async () => {
+
+    await server.register(Vision);
+
+    server.views({
+        engines: {
+            eta: {
+                compile: (src, options) => {
+
+                    const compiled = Eta.compile(src);
+
+                    return (context) => {
+
+                        return Eta.render(compiled, context);
+                    };
+                }
+            }
+        },
+        relativeTo: __dirname,
+        path: 'examples/eta/templates'
+    });
+
+    server.route({ method: 'GET', path: '/', handler: rootHandler });
+
+    await server.start();
+    console.log('Server running at:', server.info.uri);
+};
+
+provision();
+```
+
 ## Registration
 
 Vision can be registered multiple times and receives [`views manager options`](#options) as registration options.

--- a/examples/eta/index.js
+++ b/examples/eta/index.js
@@ -36,7 +36,7 @@ internals.main = async function () {
             eta: {
                 compile: (src, options) => {
 
-                    const compiled = Eta.compile(src);
+                    const compiled = Eta.compile(src, options);
 
                     return (context) => {
 
@@ -44,6 +44,16 @@ internals.main = async function () {
                     };
                 }
             }
+        },
+        /**
+         * This is the config object that gets passed to the compile function
+         * defined above. This should contain the eta configuration object
+         * described at https://eta.js.org/docs/api/configuration Only some of
+         * the configuration are relevant when using with hapijs.
+         */
+        compileOptions: {
+            autoEscape: true,
+            tags: ['{{', '}}']
         },
         relativeTo: __dirname,
         path: `templates/${internals.templatePath}`

--- a/examples/eta/index.js
+++ b/examples/eta/index.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Path = require('path');
+
+const Hapi = require('@hapi/hapi');
+const Vision = require('../..');
+const Eta = require('eta');
+
+
+const internals = {
+    templatePath: '.',
+    thisYear: new Date().getFullYear()
+};
+
+
+internals.rootHandler = function (request, h) {
+
+    const relativePath = Path.relative(`${__dirname}/../..`, `${__dirname}/templates/${internals.templatePath}`);
+
+    return h.view('index', {
+        title: `Running ${relativePath} | hapi ${request.server.version}`,
+        message: 'Hello Eta!',
+        year: internals.thisYear
+    });
+};
+
+
+internals.main = async function () {
+
+    const server = Hapi.Server({ port: 3000 });
+
+    await server.register(Vision);
+
+    server.views({
+        engines: {
+            eta: {
+                compile: (src, options) => {
+
+                    const compiled = Eta.compile(src);
+
+                    return (context) => {
+
+                        return Eta.render(compiled, context);
+                    };
+                }
+            }
+        },
+        relativeTo: __dirname,
+        path: `templates/${internals.templatePath}`
+    });
+
+    server.route({ method: 'GET', path: '/', handler: internals.rootHandler });
+
+    await server.start();
+    console.log('Server is running at ' + server.info.uri);
+};
+
+internals.main();

--- a/examples/eta/templates/index.eta
+++ b/examples/eta/templates/index.eta
@@ -1,0 +1,9 @@
+<html>
+    <body>
+        <div>
+            <h1><%= it.title %></h1>
+            <div><%= it.message %></div>
+            <p>@ hapi visionaries <%= it.year %></p>
+        </div>
+    </body>
+</html>

--- a/examples/eta/templates/index.eta
+++ b/examples/eta/templates/index.eta
@@ -1,9 +1,9 @@
 <html>
     <body>
         <div>
-            <h1><%= it.title %></h1>
-            <div><%= it.message %></div>
-            <p>@ hapi visionaries <%= it.year %></p>
+            <h1>{{= it.title }}</h1>
+            <div>{{= it.message }}</div>
+            <p>@ hapi visionaries {{= it.year }}</p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This PR adds the example for using [Etajs](https://eta.js.org/) as the template engine with vision.

Also fixes #208 