### PR TITLE
Support node v18 and hapi v21, drop node v12 and hapi v18/19

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -10,3 +10,6 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14
+      min-hapi-version: 20

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2015, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2015, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,9 +16,8 @@ exports.plugin = {
     multiple: true,
     pkg: require('../package.json'),
     requirements: {
-        hapi: '>=18.4.0'
+        hapi: '>=20.0.0'
     },
-
     register: function (server, options) {
 
         if (Object.keys(options).length > 0) {
@@ -67,7 +66,7 @@ internals.getViewsManager = function () {
 
 internals.assignManager = function (options, realm) {
 
-    realm = realm || this.realm;
+    realm = realm ?? this.realm;
     const realmState = internals.state(realm);
 
     Hoek.assert(!realmState.manager, 'Cannot set views manager more than once per realm');
@@ -149,7 +148,7 @@ internals.handler = function (route, options) {
 
 internals.state = (realm) => {
 
-    const state = realm.plugins.vision = realm.plugins.vision || {};
+    const state = realm.plugins.vision = realm.plugins.vision ?? {};
     return state;
 };
 

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -118,7 +118,7 @@ module.exports = class Manager {
 
             // When a prepare function is provided, state needs to be initialized before trying to compile and render
 
-            engine.ready = !(engine.module.prepare && typeof engine.module.prepare === 'function');
+            engine.ready = (typeof engine.module.prepare !== 'function');
 
             // Load partials and helpers
 
@@ -211,7 +211,7 @@ module.exports = class Manager {
 
                     const offset = path.slice(-1) === Path.sep ? 0 : 1;
                     const name = file.slice(path.length + offset, -Path.extname(file).length);
-                    const helper = required[name] || required.default || required;
+                    const helper = required[name] ?? required.default ?? required;
                     if (typeof helper === 'function') {
                         engine.module.registerHelper(name, helper);
                     }
@@ -225,7 +225,7 @@ module.exports = class Manager {
 
     async _prepare(template, options) {
 
-        options = options || {};
+        options = options ?? {};
 
         const fileExtension = Path.extname(template).slice(1);
         const extension = fileExtension || this._defaultExtension;
@@ -345,9 +345,7 @@ module.exports = class Manager {
 
     async _compile(template, engine, settings) {
 
-        if (engine.cache &&
-            engine.cache[template]) {
-
+        if (engine.cache?.[template]) {
             return engine.cache[template];
         }
 
@@ -406,7 +404,7 @@ module.exports = class Manager {
             context = base;
         }
 
-        context = context || {};
+        context = context ?? {};
 
         if (compiled.layout &&
             context.hasOwnProperty(compiled.settings.layoutKeyword)) {
@@ -504,7 +502,7 @@ module.exports = class Manager {
         }
 
         const extension = Path.extname(template) ? Path.extname(template).slice(1) : this._defaultExtension;
-        engine = engine || this.getEngine(extension);
+        engine = engine ?? this.getEngine(extension);
 
         const templateWithSuffix = Path.extname(template) ? template : (template + engine.suffix);
         const templateFullPath = internals.path(engine.config.relativeTo, engine.config.path, templateWithSuffix);

--- a/package.json
+++ b/package.json
@@ -19,29 +19,29 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/bounce": "2.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bounce": "^3.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x",
-    "babel-core": "6.x.x",
-    "babel-plugin-transform-react-jsx": "6.x.x",
-    "coveralls": "3.x.x",
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/lab": "^25.0.1",
+    "babel-core": "^6.0.0",
+    "babel-plugin-transform-react-jsx": "^6.0.0",
+    "coveralls": "^3.0.0",
     "ejs": "^3.1.3",
     "handlebars": "^4.5.3",
-    "hapi-react-views": "10.x.x",
-    "marko": "4.x.x",
+    "hapi-react-views": "^10.0.0",
+    "marko": "^5.21.2",
     "mustache": "^4.0.1",
-    "nunjucks": "3.x.x",
-    "pug": "3.x.x",
-    "react": "16.x.x",
-    "react-dom": "16.x.x",
-    "twig": "1.x.x"
+    "nunjucks": "^3.0.0",
+    "pug": "^3.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "twig": "^1.0.0"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -I __core-js_shared__ -m 5000",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Vision;
+
+    before(async () => {
+
+        Vision = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Vision)).to.equal([
+            'default',
+            'plugin'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Test on node v14+ and hapi v20+.
 - Update to node v18-compatible versions of hapi modules.
 - Ensure all exports are available when used as ESM module.

If this looks good, this will go out as vision v7.